### PR TITLE
[fix]: update readme.md to reflect the correct coverage percentage

### DIFF
--- a/gorillamux-redis/readme.md
+++ b/gorillamux-redis/readme.md
@@ -201,7 +201,7 @@ output should look like
 ok  	sample-app	5.032s	coverage: 71.4% of statements in ./...
 ```
 
-> **We got 55.1% without writing any e2e testcases or mocks for Redis!**
+> **We got 71.4% without writing any e2e testcases or mocks for Redis!**
 
 So no need to setup fake database/apis like Redis or write mocks for them. Keploy automatically mocks them and, **The application thinks it's talking to Redis 😄**
 


### PR DESCRIPTION
Fixes [#558](https://github.com/keploy/keploy/issues/558)

Update the [readme.md](https://github.com/keploy/samples-go/tree/main/gorillamux-redis) of `gorillamux-redis` sample to fix the inconsistency between the coverage percentage displayed in the console output and the statement below the output.

![image](https://github.com/keploy/samples-go/assets/100439627/38c26f04-96d6-459b-bdb9-25e2061a44b5)
