### PR TITLE
Fix: mongo url 

### DIFF
--- a/gin-mongo/.env
+++ b/gin-mongo/.env
@@ -1,0 +1,1 @@
+MONGO_URL=mongoDb:27017

--- a/gin-mongo/main.go
+++ b/gin-mongo/main.go
@@ -15,10 +15,11 @@ var logger *zap.Logger
 func main() {
 	logger, _ = zap.NewProduction()
 	defer logger.Sync() // flushes buffer, if any
+	os.Setenv("MONGO_URL", "mongoDb:27017") //sets mongo_url as ENV
 
 	dbName, collection := "keploy", "url-shortener"
 
-	client, err := New("mongoDb:27017", dbName)
+	client, err := New(os.Getenv("MONGO_URL"), dbName)
 	if err != nil {
 		logger.Fatal("failed to create mgo db client", zap.Error(err))
 	}

--- a/gin-mongo/main.go
+++ b/gin-mongo/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"os"
+	
+	"github.com/joho/godotenv"
 
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -15,7 +17,10 @@ var logger *zap.Logger
 func main() {
 	logger, _ = zap.NewProduction()
 	defer logger.Sync() // flushes buffer, if any
-	os.Setenv("MONGO_URL", "mongoDb:27017") //sets mongo_url as ENV
+	errENV := godotenv.Load(".env")
+	if errENV != nil {
+		logger.Fatal("faild to load ENV Variable")
+	}
 
 	dbName, collection := "keploy", "url-shortener"
 

--- a/gin-mongo/main.go
+++ b/gin-mongo/main.go
@@ -19,7 +19,7 @@ func main() {
 	defer logger.Sync() // flushes buffer, if any
 	errENV := godotenv.Load(".env")
 	if errENV != nil {
-		logger.Fatal("faild to load ENV Variable")
+		logger.Fatal("failed to load ENV Variable",zap.Error(errENV))
 	}
 
 	dbName, collection := "keploy", "url-shortener"


### PR DESCRIPTION
This pr fixes [issue](https://github.com/keploy/keploy/issues/810)

***Changes I made***
I created a env file and set mongo_url in it and use the mono_url variable in main.go file

.env file
`MONGO_URL=mongoDb:27017`

main.go file
`
        if errENV != nil {
		logger.Fatal("failed to load ENV Variable",zap.Error(errENV))
	}	
`
`
client, err := New(os.Getenv("MONGO_URL"), dbName)
`