### PR TITLE
fix(docs): Update the test command in sample gin-mongo application documentation

### DIFF
--- a/gin-mongo/README.md
+++ b/gin-mongo/README.md
@@ -84,7 +84,7 @@ Now both these API calls were captured as a testcase and should be visible on th
 Now that we have our testcase captured, run the test file.
 
 ```shell
-keploy test -c "sudo docker run -p 8080:8080 --rm --net keploy-network --name ginMongoApp gin-app:1.0 --rm ginMongoApp" --delay 10
+keploy test -c "sudo docker run -p 8080:8080 --rm --net keploy-network --name ginMongoApp gin-app:1.0" --delay 10
 ```
 
 So no need to setup dependencies like mongoDB, web-go locally or write mocks for your testing.


### PR DESCRIPTION

What do you want to add to the docs? (please state reasons if any)

[Here](https://docs.keploy.io/docs/quickstart/samples-gin/#:~:text=data%20mocks%20created.-,Run%20the%20captured%20testcases,-Now%20that%20we) the test command is keploy test -c "sudo docker run -p 8080:8080 --rm --net keploy-network --name ginMongoApp gin-app:1.0 --rm ginMongoApp" --delay 10.

It should be updated to keploy test -c "sudo docker run -p 8080:8080 --rm --net keploy-network --name ginMongoApp gin-app:1.0" --delay 10

Update the same [here](https://github.com/keploy/samples-go/tree/main/gin-mongo#run-the-captured-testcases) as well.
Repository

docs