### PR TITLE
feat: removed --rm from echo-sql readme

### DIFF
--- a/echo-sql/README.md
+++ b/echo-sql/README.md
@@ -148,7 +148,7 @@ docker build -t echo-app:1.0 .
 ## Capture the Testcases
 
 ```zsh
-keploy record -c "docker run -p 8082:8082 --rm --name echoSqlApp --network keploy-network echo-app:1.0"
+keploy record -c "docker run -p 8082:8082 --name echoSqlApp --network keploy-network echo-app:1.0"
 ```
 
 ![Testcase](./img/testcases.png?raw=true)
@@ -188,7 +188,7 @@ Now both these API calls were captured as a testcase and should be visible on th
 Now that we have our testcase captured, run the test file.
 
 ```zsh
-keploy test -c "sudo docker run -p 8082:8082 --rm --net keploy-network --name echoSqlApp echo-app:1.0 --rm echoSqlApp" --delay 10
+keploy test -c "sudo docker run -p 8082:8082 --net keploy-network --name echoSqlApp echo-app:1.0" --delay 10
 ```
 So no need to setup dependencies like mongoDB, web-go locally or write mocks for your testing.
 


### PR DESCRIPTION
- [x] Have removed --rm from the echo-sql readme in record and test cases

Closes [#987](https://github.com/keploy/keploy/issues/987)