### PR TITLE
feat: change docker-compose according to v2 for echo-sql

### DIFF
--- a/echo-sql/Dockerfile
+++ b/echo-sql/Dockerfile
@@ -1,23 +1,17 @@
-# Use the Go 1.19 base image with the bullseye tag
+# Use an official Golang runtime as a parent image
 FROM golang:1.20-bookworm
-
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates && \
-    rm -rf /var/lib/apt/lists/* 
 
 # Set the working directory inside the container
 WORKDIR /app
 
-COPY go.mod /app/
-COPY go.sum /app/
+# Copy the local package files to the container's workspace
+COPY . .
 
-RUN go mod download
+# Build the Go application
+RUN go build -o main .
 
-# Copy the contents from the local directory to the working directory in the container
-COPY . /app
+# Expose port 8080
+EXPOSE 8080
 
-RUN go build -o app .
-
-# Run the application server using "go run handler.go main.go"
-CMD ["./app"]
+# Command to run the Go application
+CMD ["./main"]

--- a/echo-sql/docker-compose.yml
+++ b/echo-sql/docker-compose.yml
@@ -1,7 +1,19 @@
-version: '3.7'
+version: "3.9"
 services:
-    postgres:
+  go-app:
+    build:
+      context: .
+    container_name: echoApp
+    ports:
+      - "8082:8082"
+    depends_on:
+      - postgres
+    networks:
+      - babab
+
+  postgres:
         image: postgres:10.5
+        container_name: postgresDb
         restart: always
         environment:
           - POSTGRES_DB=postgres
@@ -14,8 +26,8 @@ services:
           # copy the sql script to create tables
           - ./sql/init.sql:/docker-entrypoint-initdb.d/init.sql
         networks:
-          - keploy-network
+          - babab
 
 networks:
-  keploy-network:
-    external: true
+    babab: 
+      external: false

--- a/echo-sql/keploy/test-set-0/mocks.yaml
+++ b/echo-sql/keploy/test-set-0/mocks.yaml
@@ -1,0 +1,173 @@
+version: api.keploy.io/v1beta1
+kind: Postgres
+name: mocks
+spec:
+    metadata: {}
+    postgresrequests:
+        - identifier: StartupRequest
+          length: 102
+          payload: AAAAZgADAABkYXRlc3R5bGUASVNPLCBNRFkAZGF0YWJhc2UAcG9zdGdyZXMAdXNlcgBwb3N0Z3JlcwBjbGllbnRfZW5jb2RpbmcAVVRGOABleHRyYV9mbG9hdF9kaWdpdHMAMgAA
+          startup_message:
+            protocolversion: 196608
+            parameters:
+                client_encoding: UTF8
+                database: postgres
+                datestyle: ISO, MDY
+                extra_float_digits: "2"
+                user: postgres
+          auth_type: 0
+    postgresresponses:
+        - header: [R]
+          identifier: ServerResponse
+          length: 102
+          authentication_md5_password:
+            salt:
+                - 228
+                - 137
+                - 167
+                - 38
+          msg_type: 82
+          auth_type: 5
+    reqtimestampmock: 2023-11-23T16:20:53.226059464Z
+    restimestampmock: 2023-11-23T16:20:53.227347651Z
+---
+version: api.keploy.io/v1beta1
+kind: Postgres
+name: mocks
+spec:
+    metadata: {}
+    postgresrequests:
+        - header: [p]
+          identifier: ClientRequest
+          length: 102
+          password_message:
+            password: md595585db6b22cb9752075deb06fe62654
+          msg_type: 112
+          auth_type: 0
+    postgresresponses:
+        - header: [R, S, S, S, S, S, S, S, S, S, S, S, K, Z]
+          identifier: ServerResponse
+          length: 102
+          authentication_md5_password:
+            salt:
+                - 0
+                - 0
+                - 0
+                - 0
+          backend_key_data:
+            process_id: 39
+            secret_key: 764971824
+          parameter_status:
+            - name: application_name
+              value: ""
+            - name: client_encoding
+              value: UTF8
+            - name: DateStyle
+              value: ISO, MDY
+            - name: integer_datetimes
+              value: "on"
+            - name: IntervalStyle
+              value: postgres
+            - name: is_superuser
+              value: "on"
+            - name: server_encoding
+              value: UTF8
+            - name: server_version
+              value: 10.5 (Debian 10.5-2.pgdg90+1)
+            - name: session_authorization
+              value: postgres
+            - name: standard_conforming_strings
+              value: "on"
+            - name: TimeZone
+              value: UTC
+            - name: TimeZone
+              value: UTC
+            - name: TimeZone
+              value: UTC
+          ready_for_query:
+            txstatus: 73
+          msg_type: 90
+          auth_type: 0
+    reqtimestampmock: 2023-11-23T16:20:53.248527098Z
+    restimestampmock: 2023-11-23T16:20:53.248696595Z
+---
+version: api.keploy.io/v1beta1
+kind: Postgres
+name: mocks
+spec:
+    metadata: {}
+    postgresrequests:
+        - header: [P, D, S]
+          identifier: ClientRequest
+          length: 102
+          describe:
+            object_type: 83
+            name: ""
+          parse:
+            - name: ""
+              query: ' UPDATE url_map SET updated_at = $1 WHERE id = $2 '
+              parameter_oids: []
+          msg_type: 83
+          auth_type: 0
+    postgresresponses:
+        - header: ["1", t, "n", Z]
+          identifier: ServerResponse
+          length: 102
+          authentication_md5_password:
+            salt:
+                - 0
+                - 0
+                - 0
+                - 0
+          parameter_description:
+            parameteroids:
+                - 1114
+                - 25
+          ready_for_query:
+            txstatus: 73
+          msg_type: 90
+          auth_type: 0
+    reqtimestampmock: 2023-11-23T16:20:53.251132431Z
+    restimestampmock: 2023-11-23T16:20:53.25130047Z
+---
+version: api.keploy.io/v1beta1
+kind: Postgres
+name: mocks
+spec:
+    metadata: {}
+    postgresrequests:
+        - header: [B, E, S]
+          identifier: ClientRequest
+          length: 102
+          bind:
+            - parameters: [[50, 48, 50, 51, 45, 49, 49, 45, 50, 51, 32, 49, 54, 58, 50, 48, 58, 53, 51, 46, 50, 50, 51, 51, 55, 51, 52, 50, 52, 90], [76, 104, 114, 52, 66, 87, 65, 105]]
+          execute:
+            - {}
+          msg_type: 83
+          auth_type: 0
+    postgresresponses:
+        - header: ["2", C, Z]
+          identifier: ServerResponse
+          length: 102
+          authentication_md5_password:
+            salt:
+                - 0
+                - 0
+                - 0
+                - 0
+          command_complete:
+            - command_tag:
+                - 85
+                - 80
+                - 68
+                - 65
+                - 84
+                - 69
+                - 32
+                - 49
+          ready_for_query:
+            txstatus: 73
+          msg_type: 90
+          auth_type: 0
+    reqtimestampmock: 2023-11-23T16:20:53.253784679Z
+    restimestampmock: 2023-11-23T16:20:53.253808512Z

--- a/echo-sql/keploy/test-set-0/tests/test-1.yaml
+++ b/echo-sql/keploy/test-set-0/tests/test-1.yaml
@@ -1,0 +1,50 @@
+version: api.keploy.io/v1beta1
+kind: Http
+name: test-1
+spec:
+    metadata: {}
+    req:
+        method: POST
+        proto_major: 1
+        proto_minor: 1
+        url: http://localhost:8082/url
+        header:
+            Accept: '*/*'
+            Content-Length: "33"
+            Content-Type: application/json
+            Host: localhost:8082
+            User-Agent: curl/8.1.2
+        body: |-
+            {
+              "url": "https://google.com"
+            }
+        body_type: ""
+        timestamp: 2023-11-23T16:20:53.222949056Z
+    resp:
+        status_code: 200
+        header:
+            Content-Length: "66"
+            Content-Type: application/json; charset=UTF-8
+            Date: Thu, 23 Nov 2023 16:20:53 GMT
+        body: |
+            {"ts":1700756453223373424,"url":"http://localhost:8082/Lhr4BWAi"}
+        body_type: ""
+        status_message: ""
+        proto_major: 0
+        proto_minor: 0
+        timestamp: 2023-11-23T16:20:56.1993347Z
+    objects: []
+    assertions:
+        noise:
+            header.Date: []
+    created: 1700756456
+curl: |-
+    curl --request POST \
+      --url http://localhost:8082/url \
+      --header 'Accept: */*' \
+      --header 'Content-Type: application/json' \
+      --header 'Host: localhost:8082' \
+      --header 'User-Agent: curl/8.1.2' \
+      --data '{
+      "url": "https://google.com"
+    }'

--- a/echo-sql/keploy/testReports/report-1.yaml
+++ b/echo-sql/keploy/testReports/report-1.yaml
@@ -1,0 +1,7 @@
+version: api.keploy.io/v1beta1
+name: report-1
+status: RUNNING
+success: 0
+failure: 0
+total: 1
+test_set: ""

--- a/echo-sql/keploy/testReports/report-2.yaml
+++ b/echo-sql/keploy/testReports/report-2.yaml
@@ -1,0 +1,7 @@
+version: api.keploy.io/v1beta1
+name: report-2
+status: RUNNING
+success: 0
+failure: 0
+total: 1
+test_set: ""

--- a/echo-sql/keploy/testReports/report-3.yaml
+++ b/echo-sql/keploy/testReports/report-3.yaml
@@ -1,0 +1,7 @@
+version: api.keploy.io/v1beta1
+name: report-3
+status: RUNNING
+success: 0
+failure: 0
+total: 1
+test_set: ""

--- a/echo-sql/main.go
+++ b/echo-sql/main.go
@@ -24,7 +24,7 @@ func main() {
 	defer Logger.Sync() // flushes buffer
 
 	Database, err = NewConnection(ConnectionDetails{
-		host: "localhost",
+		host: "postgresDb",
 		//host:     "echo-sql-postgres-1",
 		port:     "5432",
 		user:     "postgres",


### PR DESCRIPTION
This PR has now functionality to run the echo-sql with keploy in solitude -
Steps to follow are as - 
1.  ```alias keploy='sudo docker run --pull always --name keploy-v2 -p 16789:16789 --privileged --pid=host -it -v "$(pwd)":/files -v /sys/fs/cgroup:/sys/fs/cgroup -v /sys/kernel/debug:/sys/kernel/debug -v /sys/fs/bpf:/sys/fs/bpf -v /var/run/docker.sock:/var/run/docker.sock --rm ghcr.io/keploy/keploy'```
2. keploy record -c "docker compose up" --containerName "echoApp"
3. make an api call as - 
```
curl --request POST \
  --url http://localhost:8082/url \
  --header 'content-type: application/json' \
  --data '{
  "url": "https://google.com"
}'
```
4. Now run it in test mode- keploy test -c "docker compose up" --containerName "echoApp" --delay 10
