### PR TITLE
bugs: fix hardcoded container name

### DIFF
--- a/mux-sql/main.go
+++ b/mux-sql/main.go
@@ -8,7 +8,7 @@ func main() {
 	a := &App{}
 	err := a.Initialize(
 		"localhost", // postgres host
-		//Change to `mux-sql-postgres-1` when using Docker to run keploy
+		//Change to `postgres` when using Docker to run keploy
 		"postgres", // username
 		"password", // password
 		"postgres") // db_name


### PR DESCRIPTION
The comment recommended changing the host for postgres to `mux-sql-postgres-1` which works only when the parent directory is named mux-sql. Changed this to a `postgres` which is the name of the service in docker-compose.yml file and will work regardless.