### PR TITLE
feat: reduce image size from 1GB to 29MB

### DIFF
--- a/gin-mongo/Dockerfile
+++ b/gin-mongo/Dockerfile
@@ -1,17 +1,45 @@
-# Use an official Golang runtime as a parent image
-FROM golang:1.20-bookworm
+# === Build Stage ===
+FROM golang:1.20-bookworm AS build-stage
 
-# Set the working directory inside the container
+# Set the working directory
 WORKDIR /app
 
-# Copy the local package files to the container's workspace
-COPY . .
+# Copy the Go module files and download dependencies
+COPY go.mod go.sum ./
+RUN go mod download
 
-# Build the Go application
-RUN go build -o main .
 
-# Expose port 8080
+# Copy the contents of the current directory into the build container
+COPY *.go ./
+
+# Build the binary
+RUN CGO_ENABLED=0 go build -o /main 
+
+# === Runtime Stage ===
+FROM alpine
+
+# Add groups and user to run the app and install dumb-init package
+RUN addgroup -S keploy \ 
+&& adduser -S keploy -G keploy -h /home/keploy \
+&& mkdir -p /home/keploy/app \
+&& chown -R keploy:keploy /home/keploy/app \ 
+&& apk add --no-cache dumb-init \ 
+&& rm -rf /var/cache/apk/*
+
+# Change working directory
+WORKDIR /home/keploy/app
+
+# Copy the binary from build-stage and paste it in app directory
+COPY --from=build-stage --chown=keploy:keploy /main /home/keploy/app/main 
+
+# Set the entrypoint
+ENTRYPOINT ["dumb-init"]
+
+# Set user
+USER keploy
+
+# Expose the port
 EXPOSE 8080
 
-# Command to run the Go application
+# Run the binary
 CMD ["./main"]

--- a/gin-mongo/Dockerfile
+++ b/gin-mongo/Dockerfile
@@ -16,7 +16,7 @@ COPY *.go ./
 RUN CGO_ENABLED=0 go build -o /main 
 
 # === Runtime Stage ===
-FROM alpine
+FROM alpine:3.19
 
 # Add groups and user to run the app and install dumb-init package
 RUN addgroup -S keploy \ 


### PR DESCRIPTION
# Issue
- closes https://github.com/keploy/keploy/issues/1349
---
Reduce the size using [multi-stage](https://docs.docker.com/language/golang/build-images/#multi-stage-builds) feature of docker

![Screenshot from 2024-01-16 22-53-22](https://github.com/keploy/samples-go/assets/49451740/8ea6014b-804e-437e-9e1b-5195d73c1e85)
