### PR TITLE
Some fixes to allow running echo sql app in one go

### DIFF
--- a/echo-sql/docker-compose.yml
+++ b/echo-sql/docker-compose.yml
@@ -30,4 +30,5 @@ services:
 
 networks:
     keploy-network: 
-      external: false
+      external: true
+      name: keploy-network

--- a/echo-sql/docker-compose.yml
+++ b/echo-sql/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     depends_on:
       - postgres
     networks:
-      - babab
+      - keploy-network
 
   postgres:
         image: postgres:10.5
@@ -26,8 +26,8 @@ services:
           # copy the sql script to create tables
           - ./sql/init.sql:/docker-entrypoint-initdb.d/init.sql
         networks:
-          - babab
+          - keploy-network
 
 networks:
-    babab: 
+    keploy-network: 
       external: false

--- a/echo-sql/main.go
+++ b/echo-sql/main.go
@@ -31,7 +31,7 @@ func main() {
 	defer handleDeferError(Logger.Sync()) // flushes buffer
 
 	Database, err = NewConnection(ConnectionDetails{
-		host: "postgresDb",
+		host: "postgres",
 		// host: "localhost" when using natively
 		//host:     "echo-sql-postgres-1",
 		port:     "5432",


### PR DESCRIPTION
Changes:
1. Changed network name to `keploy-network` since that is what `keploy` creates when we install `keploy`
2. Changed host name to `postgres` from `postgresDB` because docker uses service name


There will be some changes that will need to be added in docs as well to ensure that user is able to run this app in one-go

Some suggestions like adding `--rm` command in `keploy record ...` command so that user doesn't see the error that container is still up/or change the app name.
Open to suggestions. For now this also seemed good so sending a PR for the same.