### PR TITLE
fix: Removed milliseconds from the timestamps

### DIFF
--- a/echo-mysql/main.go
+++ b/echo-mysql/main.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"time"
 
-	"github.com/joho/godotenv"
 	"github.com/hermione/echo-mysql/uss"
+	"github.com/joho/godotenv"
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/middleware"
 )
@@ -66,6 +67,7 @@ func StartHTTPServer() {
 		if err != nil {
 			return c.String(http.StatusInternalServerError, fmt.Sprintf("Failed Persisiting Entity with Error %s", err.Error()))
 		} else {
+			req.UpdatedAt = req.UpdatedAt.Truncate(time.Second)
 			return c.JSON(http.StatusOK, req)
 		}
 	})

--- a/echo-mysql/uss/store.go
+++ b/echo-mysql/uss/store.go
@@ -13,7 +13,7 @@ type ShortCodeInfo struct {
 	UID       uint64    `json:"id" sql:"AUTO_INCREMENT" gorm:"primary_key"`
 	ShortCode string    `json:"shortcode" gorm:"uniqueIndex"`
 	URL       string    `json:"url"`
-	UpdatedAt time.Time `json:"updated_at"`
+	UpdatedAt time.Time `json:"updated_at" gorm:"datetime(0);autoUpdateTime"`
 }
 
 type USSStore struct {


### PR DESCRIPTION
This PR removes the milliseconds from the updated_at field to make it work for the golang_mysql_linx workflow.

fixes [#2286](https://github.com/keploy/keploy/issues/2286)