### PR TITLE
ci: add missing apps to build and lint CI coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,27 +13,20 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.22' 
+          go-version: 'stable'
 
       - name: Build projects
         run: |
           #!/bin/bash
           cd /home/runner/work/samples-go/samples-go
 
-          # Dirs that require a newer Go toolchain than the workflow provides
-          SKIP_DIRS=("dns-mock-test")
-
           for dir in */; do
             dir_name="${dir%/}"
-            if [[ " ${SKIP_DIRS[*]} " =~ " ${dir_name} " ]]; then
-              echo "Skipping $dir (requires newer Go toolchain)"
-              continue
-            fi
             if [ -d "$dir" ] && [ -f "${dir}go.mod" ]; then
               echo "Building project in $dir"
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -26,29 +26,47 @@ jobs:
       fail-fast: false
       matrix:
         working-directory:
+          - book-store-inventory
+          - connect-tunnel
+          - dns-dedup
+          - dns-mock-test
           - echo-mysql
           - echo-sql
           - fasthttp-postgres
           - gin-mongo
           - gin-redis
+          - go-dedup
+          - go-docker-timefreeze
           - go-grpc
           - go-jwt
+          - go-memory-load
+          - go-redis
           - go-twilio
           - graphql-sql
+          - grpc-mongo
+          - grpc-secret
           - http-pokeapi
+          - http-postgres
+          - http-sse
           - mux-elasticsearch
           - mux-mysql
           - mux-sql
+          - proxy-stress-test
+          - risk-profile
           - S3-Keploy
+          - simple-grpc
+          - sqs-samples
+          - sse-preflight
+          - sse-redis
           - sse-svelte
+          - tls-dadjoke
           - users-profile
-          - book-store-inventory
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: '1.23.4'
+          go-version: 'stable'
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/connect-tunnel/main.go
+++ b/connect-tunnel/main.go
@@ -1,3 +1,4 @@
+// Package main implements a minimal HTTP app for testing Keploy's CONNECT tunnel recording and replay.
 package main
 
 import (
@@ -69,7 +70,7 @@ func handleViaProxy(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusBadGateway, "upstream request failed; check proxy connectivity (HTTP_PROXY/HTTPS_PROXY), DNS resolution, and target reachability")
 		return
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	const maxBody = 1 << 20 // 1 MiB
 	lr := io.LimitReader(resp.Body, maxBody+1)

--- a/dns-dedup/main.go
+++ b/dns-dedup/main.go
@@ -1,3 +1,4 @@
+// Package main is a test app for Keploy DNS mock deduplication scenarios.
 package main
 
 import (
@@ -27,9 +28,11 @@ func main() {
 		domain = os.Args[1]
 	}
 
-	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, "ok")
+		if _, err := fmt.Fprint(w, "ok"); err != nil {
+			fmt.Fprintf(os.Stderr, "health write error: %v\n", err)
+		}
 	})
 
 	// Single DNS lookup
@@ -45,10 +48,12 @@ func main() {
 		}
 		sort.Strings(ips) // deterministic order for replay comparison
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		if err := json.NewEncoder(w).Encode(map[string]interface{}{
 			"domain": d,
 			"ips":    ips,
-		})
+		}); err != nil {
+			fmt.Fprintf(os.Stderr, "encode error: %v\n", err)
+		}
 	})
 
 	// Many DNS lookups for the same domain — the key dedup scenario.
@@ -89,12 +94,14 @@ func main() {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		if err := json.NewEncoder(w).Encode(map[string]interface{}{
 			"domain":         d,
 			"total_queries":  n,
 			"unique_ip_sets": len(seen),
 			"results":        results,
-		})
+		}); err != nil {
+			fmt.Fprintf(os.Stderr, "encode error: %v\n", err)
+		}
 	})
 
 	port := "8086"

--- a/dns-mock-test/main.go
+++ b/dns-mock-test/main.go
@@ -1,3 +1,4 @@
+// Package main implements an HTTP server for DNS query testing via the miekg/dns library.
 package main
 
 import (
@@ -6,6 +7,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"os"
 
 	"github.com/miekg/dns"
 )
@@ -131,9 +133,7 @@ func handleTXTRecord(w http.ResponseWriter, r *http.Request) {
 	var txts []string
 	for _, rr := range records {
 		if txt, ok := rr.(*dns.TXT); ok {
-			for _, t := range txt.Txt {
-				txts = append(txts, t)
-			}
+			txts = append(txts, txt.Txt...)
 		}
 	}
 
@@ -283,21 +283,25 @@ func queryDNS(domain string, qtype uint16) ([]dns.RR, error) {
 }
 
 // Health check endpoint
-func handleHealth(w http.ResponseWriter, r *http.Request) {
+func handleHealth(w http.ResponseWriter, _ *http.Request) {
 	respondWithJSON(w, map[string]string{"status": "healthy", "protocol": "TCP"})
 }
 
 // Helper function to respond with JSON
 func respondWithJSON(w http.ResponseWriter, data interface{}) {
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(data)
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		fmt.Fprintf(os.Stderr, "json encode error: %v\n", err)
+	}
 }
 
 // Helper function to respond with error
 func respondWithError(w http.ResponseWriter, message string, statusCode int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
-	json.NewEncoder(w).Encode(map[string]string{"error": message})
+	if err := json.NewEncoder(w).Encode(map[string]string{"error": message}); err != nil {
+		fmt.Fprintf(os.Stderr, "json encode error: %v\n", err)
+	}
 }
 
 func main() {

--- a/go-dedup/main.go
+++ b/go-dedup/main.go
@@ -1,7 +1,9 @@
+// Package main provides a multi-endpoint Gin HTTP server for Keploy deduplication testing.
 package main
 
 import (
 	"fmt"
+	"log"
 	"math/rand"
 	"net/http"
 	"time"
@@ -55,8 +57,8 @@ func main() {
 
 	// 3. An endpoint that randomly returns 0 or 1
 	router.GET("/random", func(c *gin.Context) {
-		rand.Seed(time.Now().UnixNano())
-		randomNumber := rand.Intn(2)
+		r := rand.New(rand.NewSource(time.Now().UnixNano())) //nolint:gosec
+		randomNumber := r.Intn(2)
 		c.JSON(http.StatusOK, gin.H{"value": randomNumber})
 	})
 
@@ -253,5 +255,7 @@ func main() {
 	router.GET("/session/info", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"session_id": "xyz-123", "active": true}) })
 
 	// Start the HTTP server on port 8080
-	router.Run(":8080")
+	if err := router.Run(":8080"); err != nil {
+		log.Fatalf("server failed: %v", err)
+	}
 }

--- a/go-docker-timefreeze/main.go
+++ b/go-docker-timefreeze/main.go
@@ -1,3 +1,4 @@
+// Package main implements a JWT-based HTTP server for Keploy time-freeze testing.
 package main
 
 import (
@@ -18,7 +19,7 @@ type Claims struct {
 	jwt.RegisteredClaims
 }
 
-func loginHandler(w http.ResponseWriter, r *http.Request) {
+func loginHandler(w http.ResponseWriter, _ *http.Request) {
 	fmt.Println("Login attempt at :", time.Now())
 	expirationTime := time.Now().Add(10 * time.Second)
 
@@ -44,7 +45,9 @@ func loginHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	w.Write(jsonResponse)
+	if _, err = w.Write(jsonResponse); err != nil {
+		log.Printf("write error: %v", err)
+	}
 }
 
 func insecureExpiryOnlyMiddleware(next http.Handler) http.Handler {
@@ -74,9 +77,11 @@ func insecureExpiryOnlyMiddleware(next http.Handler) http.Handler {
 	})
 }
 
-func protectedHandler(w http.ResponseWriter, r *http.Request) {
+func protectedHandler(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("Welcome to the protected area!"))
+	if _, err := w.Write([]byte("Welcome to the protected area!")); err != nil {
+		log.Printf("write error: %v", err)
+	}
 }
 
 // checkTimeHandler checks if a client-provided timestamp is within 1 second of the server time.
@@ -86,7 +91,9 @@ func checkTimeHandler(w http.ResponseWriter, r *http.Request) {
 	if clientTimeStr == "" {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(map[string]string{"error": "Missing 'ts' query parameter"})
+		if err := json.NewEncoder(w).Encode(map[string]string{"error": "Missing 'ts' query parameter"}); err != nil {
+			log.Printf("encode error: %v", err)
+		}
 		return
 	}
 
@@ -95,7 +102,9 @@ func checkTimeHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid timestamp format. Must be a Unix timestamp in seconds."})
+		if err := json.NewEncoder(w).Encode(map[string]string{"error": "Invalid timestamp format. Must be a Unix timestamp in seconds."}); err != nil {
+			log.Printf("encode error: %v", err)
+		}
 		return
 	}
 

--- a/go-memory-load/cmd/api/main.go
+++ b/go-memory-load/cmd/api/main.go
@@ -1,3 +1,4 @@
+// Package main is the entry point for the load-test API server.
 package main
 
 import (
@@ -34,7 +35,7 @@ func main() {
 		logger.Error("connect postgres", "error", err)
 		os.Exit(1)
 	}
-	defer db.Close()
+	defer db.Close() //nolint:errcheck
 
 	if err := database.EnsureRuntimeSchema(ctx, db); err != nil {
 		logger.Error("ensure runtime schema", "error", err)

--- a/go-memory-load/internal/config/config.go
+++ b/go-memory-load/internal/config/config.go
@@ -1,3 +1,4 @@
+// Package config handles configuration loading from environment variables.
 package config
 
 import (

--- a/go-memory-load/internal/database/postgres.go
+++ b/go-memory-load/internal/database/postgres.go
@@ -1,3 +1,4 @@
+// Package database provides PostgreSQL connection helpers.
 package database
 
 import (
@@ -6,7 +7,7 @@ import (
 	"fmt"
 	"time"
 
-	_ "github.com/jackc/pgx/v5/stdlib"
+	_ "github.com/jackc/pgx/v5/stdlib" // pgx driver for database/sql
 )
 
 func Open(ctx context.Context, dsn string) (*sql.DB, error) {

--- a/go-memory-load/internal/httpapi/server.go
+++ b/go-memory-load/internal/httpapi/server.go
@@ -1,3 +1,4 @@
+// Package httpapi provides the HTTP API handlers for the load-test server.
 package httpapi
 
 import (
@@ -304,7 +305,7 @@ func writeJSON(w http.ResponseWriter, statusCode int, payload any) {
 }
 
 func decodeJSON(r *http.Request, target any) error {
-	defer r.Body.Close()
+	defer r.Body.Close() //nolint:errcheck
 
 	decoder := json.NewDecoder(r.Body)
 	decoder.DisallowUnknownFields()

--- a/go-memory-load/internal/store/models.go
+++ b/go-memory-load/internal/store/models.go
@@ -1,3 +1,4 @@
+// Package store defines data models for the load-test API.
 package store
 
 import "time"

--- a/go-memory-load/internal/store/store.go
+++ b/go-memory-load/internal/store/store.go
@@ -168,7 +168,7 @@ func (s *Store) CreateOrder(ctx context.Context, req CreateOrderRequest) (Order,
 	if err != nil {
 		return Order{}, fmt.Errorf("begin transaction: %w", err)
 	}
-	defer tx.Rollback()
+	defer tx.Rollback() //nolint:errcheck
 
 	var customerExists bool
 	if err := tx.QueryRowContext(
@@ -291,7 +291,7 @@ func (s *Store) GetOrder(ctx context.Context, orderID string) (Order, error) {
 		}
 		return Order{}, fmt.Errorf("query order: %w", err)
 	}
-	defer rows.Close()
+	defer rows.Close() //nolint:errcheck
 
 	var order Order
 	found := false
@@ -484,7 +484,7 @@ func (s *Store) SearchOrders(ctx context.Context, params OrderSearchParams) ([]O
 	if err != nil {
 		return nil, fmt.Errorf("query order search: %w", err)
 	}
-	defer rows.Close()
+	defer rows.Close() //nolint:errcheck
 
 	results := make([]OrderSearchResult, 0, params.Limit)
 	for rows.Next() {
@@ -575,7 +575,7 @@ func (s *Store) TopProducts(ctx context.Context, days, limit int) ([]TopProduct,
 	if err != nil {
 		return nil, fmt.Errorf("query top products: %w", err)
 	}
-	defer rows.Close()
+	defer rows.Close() //nolint:errcheck
 
 	results := make([]TopProduct, 0, limit)
 	for rows.Next() {

--- a/go-redis/main.go
+++ b/go-redis/main.go
@@ -1,3 +1,4 @@
+// Package main provides a Redis-backed HTTP API sample for Keploy testing.
 package main
 
 import (
@@ -64,7 +65,9 @@ func main() {
 	router.GET("/health", healthCheck)
 
 	log.Println("Server running on :8080")
-	router.Run(":8080")
+	if err := router.Run(":8080"); err != nil {
+		log.Fatalf("server failed: %v", err)
+	}
 }
 
 // Handlers for complex data structures
@@ -321,9 +324,9 @@ func getProductFromRedis(key string) (*Product, error) {
 		Quantity: parseInt(data["quantity"]),
 	}
 
-	json.Unmarshal([]byte(data["metadata"]), &p.Metadata)
-	json.Unmarshal([]byte(data["related_ids"]), &p.RelatedIDs)
-	json.Unmarshal([]byte(data["categories"]), &p.Categories)
+	_ = json.Unmarshal([]byte(data["metadata"]), &p.Metadata)
+	_ = json.Unmarshal([]byte(data["related_ids"]), &p.RelatedIDs)
+	_ = json.Unmarshal([]byte(data["categories"]), &p.Categories)
 
 	return p, nil
 }

--- a/grpc-mongo/client/main.go
+++ b/grpc-mongo/client/main.go
@@ -1,3 +1,4 @@
+// Package main implements the gRPC client for the grpc-mongo sample.
 package main
 
 import (
@@ -22,16 +23,16 @@ func main() {
 	// dial with timeout
 	dialCtx, cancelDial := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancelDial()
-	conn, err := grpc.DialContext(
+	conn, err := grpc.DialContext( //nolint:staticcheck
 		dialCtx,
 		addr,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithBlock(),
+		grpc.WithBlock(), //nolint:staticcheck
 	)
 	if err != nil {
 		log.Fatalf("dial: %v", err)
 	}
-	defer conn.Close()
+	defer conn.Close() //nolint:errcheck
 
 	c := pb.NewTokenServiceClient(conn)
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)

--- a/grpc-mongo/main.go
+++ b/grpc-mongo/main.go
@@ -1,3 +1,4 @@
+// Package main implements the gRPC server for the grpc-mongo sample.
 package main
 
 import (
@@ -86,7 +87,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("mongo connect: %v", err)
 	}
-	defer client.Disconnect(context.Background())
+	defer client.Disconnect(context.Background()) //nolint:errcheck
 
 	col := client.Database("keploydb").Collection("tokens")
 	s := &server{col: col}

--- a/grpc-mongo/server/main.go
+++ b/grpc-mongo/server/main.go
@@ -1,3 +1,4 @@
+// Package main implements the gRPC server for the grpc-mongo sample (server subdirectory).
 package main
 
 import (
@@ -86,7 +87,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("mongo connect: %v", err)
 	}
-	defer client.Disconnect(context.Background())
+	defer client.Disconnect(context.Background()) //nolint:errcheck
 
 	col := client.Database("keploydb").Collection("tokens")
 	s := &server{col: col}

--- a/grpc-secret/main.go
+++ b/grpc-secret/main.go
@@ -1,3 +1,4 @@
+// Package main implements a gRPC server for secrets management with JWT authentication.
 package main
 
 import (
@@ -638,7 +639,7 @@ func setResponseMetadata(ctx context.Context) error {
 func logIncomingHeaders(method string, jwt, apiKey, sessionToken string) {
 	log.Printf("[%s] Incoming headers:", method)
 	if jwt != "" {
-		log.Printf("  - Authorization (JWT): %s", jwt[:min(len(jwt), 50)]+"...")
+		log.Printf("  - Authorization (JWT): %s", jwt[:minInt(len(jwt), 50)]+"...")
 	}
 	if apiKey != "" {
 		log.Printf("  - X-Api-Key: %s", apiKey)
@@ -648,7 +649,7 @@ func logIncomingHeaders(method string, jwt, apiKey, sessionToken string) {
 	}
 }
 
-func min(a, b int) int {
+func minInt(a, b int) int {
 	if a < b {
 		return a
 	}

--- a/http-postgres/db/db.go
+++ b/http-postgres/db/db.go
@@ -1,3 +1,4 @@
+// Package db provides PostgreSQL connection and migration helpers.
 package db
 
 import (
@@ -5,7 +6,7 @@ import (
 	"fmt"
 	"os"
 
-	_ "github.com/lib/pq"
+	_ "github.com/lib/pq" // pq driver for database/sql
 )
 
 func Connect() (*sql.DB, error) {

--- a/http-postgres/handler/handler.go
+++ b/http-postgres/handler/handler.go
@@ -1,8 +1,10 @@
+// Package handler provides HTTP handlers for the pg-replicate API.
 package handler
 
 import (
 	"database/sql"
 	"encoding/json"
+	"log"
 	"net/http"
 	"strings"
 )
@@ -60,13 +62,13 @@ func (h *Handler) CreateCompany(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusCreated, company)
 }
 
-func (h *Handler) ListCompanies(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) ListCompanies(w http.ResponseWriter, _ *http.Request) {
 	rows, err := h.db.Query("SELECT id, name, created_at FROM companies ORDER BY id")
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, ErrorResponse{Error: "failed to list companies"})
 		return
 	}
-	defer rows.Close()
+	defer rows.Close() //nolint:errcheck
 
 	companies := []Company{}
 	for rows.Next() {
@@ -106,5 +108,7 @@ func (h *Handler) GetCompany(w http.ResponseWriter, r *http.Request) {
 func writeJSON(w http.ResponseWriter, status int, data any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(data)
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		log.Printf("json encode error: %v", err)
+	}
 }

--- a/http-postgres/handler/projects.go
+++ b/http-postgres/handler/projects.go
@@ -131,13 +131,13 @@ func (h *Handler) UpdateProject(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, p)
 }
 
-func (h *Handler) ListProjects(w http.ResponseWriter, r *http.Request) {
+func (h *Handler) ListProjects(w http.ResponseWriter, _ *http.Request) {
 	rows, err := h.db.Query("SELECT id, name, status, created_at, updated_at FROM projects ORDER BY created_at")
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, ErrorResponse{Error: "failed to list projects"})
 		return
 	}
-	defer rows.Close()
+	defer rows.Close() //nolint:errcheck
 
 	projects := []Project{}
 	for rows.Next() {

--- a/http-postgres/main.go
+++ b/http-postgres/main.go
@@ -1,3 +1,4 @@
+// Package main is the entry point for the pg-replicate HTTP server.
 package main
 
 import (
@@ -13,7 +14,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to connect to database: %v", err)
 	}
-	defer database.Close()
+	defer database.Close() //nolint:errcheck
 
 	if err := db.Migrate(database); err != nil {
 		log.Fatalf("failed to run migrations: %v", err)

--- a/http-sse/main.go
+++ b/http-sse/main.go
@@ -1,3 +1,4 @@
+// Package main implements an HTTP and SSE server for Keploy SSE port reproduction testing.
 package main
 
 import (
@@ -90,7 +91,7 @@ func httpMux() http.Handler {
 	mux := http.NewServeMux()
 
 	// 1) health
-	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]any{
 			"ok":   true,
 			"port": 8000,
@@ -98,7 +99,7 @@ func httpMux() http.Handler {
 	})
 
 	// 2) simple GET
-	mux.HandleFunc("/api/hello", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/hello", func(w http.ResponseWriter, _ *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]any{
 			"msg":  "hello from http",
 			"port": 8000,
@@ -132,7 +133,7 @@ func httpMux() http.Handler {
 	})
 
 	// 5) time endpoint (dynamic, but ok for record; in replay you can mark noise if you want)
-	mux.HandleFunc("/api/time", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/time", func(w http.ResponseWriter, _ *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]any{
 			"now":  time.Now().UTC().Format(time.RFC3339Nano),
 			"port": 8000,
@@ -156,7 +157,7 @@ func httpMux() http.Handler {
 	})
 
 	// 7) ping — also served on :8050 to test port mapping
-	mux.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/ping", func(w http.ResponseWriter, _ *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]any{
 			"pong": true,
 			"from": "http",
@@ -165,13 +166,13 @@ func httpMux() http.Handler {
 
 	// IMPORTANT: SSE routes MUST NOT be served on HTTP port.
 	// If replay routes SSE traffic to HTTP :8000 => deterministic 404.
-	mux.HandleFunc("/subscribe/student/events", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/subscribe/student/events", func(w http.ResponseWriter, _ *http.Request) {
 		writeJSON(w, http.StatusNotFound, map[string]any{
 			"error": "SSE endpoint is NOT served on the HTTP port (:8000).",
 			"hint":  "This simulates wrong port mapping during replay.",
 		})
 	})
-	mux.HandleFunc("/subscribe/teacher/events", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/subscribe/teacher/events", func(w http.ResponseWriter, _ *http.Request) {
 		writeJSON(w, http.StatusNotFound, map[string]any{
 			"error": "Teacher SSE endpoint is NOT served on the HTTP port (:8000).",
 			"hint":  "This simulates wrong port mapping during replay.",
@@ -195,7 +196,7 @@ func httpMux() http.Handler {
 func pingMux() http.Handler {
 	mux := http.NewServeMux()
 
-	mux.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/ping", func(w http.ResponseWriter, _ *http.Request) {
 		writeJSON(w, http.StatusOK, map[string]any{
 			"pong": true,
 			"from": "http",
@@ -291,8 +292,10 @@ func streamSSE(w http.ResponseWriter, r *http.Request, kind, id string) {
 
 func writeSSE(w http.ResponseWriter, event string, payload any) {
 	b, _ := json.Marshal(payload)
-	fmt.Fprintf(w, "event:%s\n", event)
-	fmt.Fprintf(w, "data:%s\n\n", string(b))
+	if _, err := fmt.Fprintf(w, "event:%s\n", event); err != nil {
+		return
+	}
+	_, _ = fmt.Fprintf(w, "data:%s\n\n", string(b))
 }
 
 /* ------------------------------ helpers -------------------------------- */

--- a/proxy-stress-test/main.go
+++ b/proxy-stress-test/main.go
@@ -1,3 +1,4 @@
+// Package main is a proxy stress-test app for Keploy regression testing.
 package main
 
 import (
@@ -216,7 +217,7 @@ func fetchHTTPS(ctx context.Context, targetURL string) (int, string, error) {
 	if err != nil {
 		return 0, "", err
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 	body, _ := io.ReadAll(resp.Body)
 	return resp.StatusCode, string(body), nil
 }
@@ -294,7 +295,7 @@ func transferHandler(db *sql.DB) http.HandlerFunc {
 			if rowErr := rows.Err(); rowErr != nil {
 				result.DBError = rowErr.Error()
 			}
-			rows.Close()
+			rows.Close() //nolint:errcheck
 			result.DBLargeRows = count
 		}
 
@@ -314,13 +315,15 @@ func transferHandler(db *sql.DB) http.HandlerFunc {
 					break
 				}
 			}
-			wideRows.Close()
+			wideRows.Close() //nolint:errcheck
 		}
 
 		result.Duration = time.Since(start).String()
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(result)
+		if err := json.NewEncoder(w).Encode(result); err != nil {
+			log.Printf("encode: %v", err)
+		}
 	}
 }
 
@@ -385,7 +388,7 @@ func batchTransferHandler(db *sql.DB) http.HandlerFunc {
 				_ = rows.Scan(&id, &name, &desc, &payload)
 				dbRows++
 			}
-			rows.Close()
+			rows.Close() //nolint:errcheck
 		}
 
 		res := batchResult{
@@ -398,7 +401,9 @@ func batchTransferHandler(db *sql.DB) http.HandlerFunc {
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(res)
+		if err := json.NewEncoder(w).Encode(res); err != nil {
+			log.Printf("encode: %v", err)
+		}
 	}
 }
 
@@ -412,14 +417,16 @@ func healthHandler(db *sql.DB) http.HandlerFunc {
 			status = "db_down: " + err.Error()
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{"status": status})
+		if err := json.NewEncoder(w).Encode(map[string]string{"status": status}); err != nil {
+			log.Printf("encode: %v", err)
+		}
 	}
 }
 
 // /api/post-transfer — POST endpoint to trigger SQS parser misclassification (Issue 4)
 // The SQS parser matches any buffer starting with "POST " — this HTTP POST through
 // the CONNECT tunnel will be first evaluated by the SQS parser before falling back.
-func postTransferHandler(db *sql.DB) http.HandlerFunc {
+func postTransferHandler(_ *sql.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		ctx := r.Context()
@@ -444,17 +451,19 @@ func postTransferHandler(db *sql.DB) http.HandlerFunc {
 			respErr = err.Error()
 		} else {
 			status = resp.StatusCode
-			resp.Body.Close()
+			resp.Body.Close() //nolint:errcheck
 		}
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		if err := json.NewEncoder(w).Encode(map[string]interface{}{
 			"method":   "POST",
 			"target":   postTarget,
 			"status":   status,
 			"error":    respErr,
 			"duration": time.Since(start).String(),
-		})
+		}); err != nil {
+			log.Printf("encode: %v", err)
+		}
 	}
 }
 
@@ -483,7 +492,7 @@ func backgroundNoise(ctx context.Context) {
 				}
 				resp, err := client.Do(req)
 				if err == nil {
-					resp.Body.Close()
+					resp.Body.Close() //nolint:errcheck
 				}
 			}()
 		}
@@ -511,7 +520,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to connect to database (check DATABASE_URL env var): %v", err)
 	}
-	defer db.Close()
+	defer db.Close() //nolint:errcheck
 
 	// Start background noise (fills error channel during replay)
 	go backgroundNoise(ctx)

--- a/risk-profile/main.go
+++ b/risk-profile/main.go
@@ -1,3 +1,4 @@
+// Package main provides a risk-profile HTTP server for Keploy testing.
 package main
 
 import (
@@ -18,7 +19,7 @@ var originalUsers = []UserV1{
 	{ID: 1, Name: "Alice", Email: "alice@example.com"},
 }
 
-func getUsersLowRisk(w http.ResponseWriter, r *http.Request) {
+func getUsersLowRisk(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	user := originalUsers[0]
 	response := map[string]interface{}{
@@ -27,10 +28,12 @@ func getUsersLowRisk(w http.ResponseWriter, r *http.Request) {
 		"email":     user.Email,
 		"timestamp": time.Now().Unix(),
 	}
-	json.NewEncoder(w).Encode(response)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		log.Printf("encode: %v", err)
+	}
 }
 
-func getUsersMediumRisk(w http.ResponseWriter, r *http.Request) {
+func getUsersMediumRisk(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	user := originalUsers[0]
 	response := map[string]interface{}{
@@ -39,10 +42,12 @@ func getUsersMediumRisk(w http.ResponseWriter, r *http.Request) {
 		"email":     user.Email,
 		"timestamp": time.Now().Unix(),
 	}
-	json.NewEncoder(w).Encode(response)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		log.Printf("encode: %v", err)
+	}
 }
 
-func getUsersMediumRiskWithAddition(w http.ResponseWriter, r *http.Request) {
+func getUsersMediumRiskWithAddition(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	user := originalUsers[0]
 	response := map[string]interface{}{
@@ -51,10 +56,12 @@ func getUsersMediumRiskWithAddition(w http.ResponseWriter, r *http.Request) {
 		"email":     user.Email,
 		"timestamp": time.Now().Unix(),
 	}
-	json.NewEncoder(w).Encode(response)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		log.Printf("encode: %v", err)
+	}
 }
 
-func getUsersHighRiskType(w http.ResponseWriter, r *http.Request) {
+func getUsersHighRiskType(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	user := originalUsers[0]
 	response := map[string]interface{}{
@@ -63,10 +70,12 @@ func getUsersHighRiskType(w http.ResponseWriter, r *http.Request) {
 		"email":     user.Email,
 		"timestamp": time.Now().Unix(),
 	}
-	json.NewEncoder(w).Encode(response)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		log.Printf("encode: %v", err)
+	}
 }
 
-func getUsersHighRiskRemoval(w http.ResponseWriter, r *http.Request) {
+func getUsersHighRiskRemoval(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	user := originalUsers[0]
 	response := map[string]interface{}{
@@ -75,60 +84,72 @@ func getUsersHighRiskRemoval(w http.ResponseWriter, r *http.Request) {
 		"email":     user.Email,
 		"timestamp": time.Now().Unix(),
 	}
-	json.NewEncoder(w).Encode(response)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		log.Printf("encode: %v", err)
+	}
 }
 
-func statusChangeHighRisk(w http.ResponseWriter, r *http.Request) {
+func statusChangeHighRisk(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	response := map[string]interface{}{
 		"status":    "OK",
 		"timestamp": time.Now().Unix(),
 	}
-	json.NewEncoder(w).Encode(response)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		log.Printf("encode: %v", err)
+	}
 }
 
-func contentTypeChangeHighRisk(w http.ResponseWriter, r *http.Request) {
+func contentTypeChangeHighRisk(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	response := map[string]interface{}{
 		"message":   "This is JSON.",
 		"timestamp": time.Now().Unix(),
 	}
-	json.NewEncoder(w).Encode(response)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		log.Printf("encode: %v", err)
+	}
 }
 
-func headerChangeMediumRisk(w http.ResponseWriter, r *http.Request) {
+func headerChangeMediumRisk(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("X-Custom-Header", "initial-value-123")
 	w.WriteHeader(http.StatusOK)
 	response := map[string]interface{}{
 		"status":    "header test",
 		"timestamp": time.Now().Unix(),
 	}
-	json.NewEncoder(w).Encode(response)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		log.Printf("encode: %v", err)
+	}
 }
 
-func statusBodyChange(w http.ResponseWriter, r *http.Request) {
+func statusBodyChange(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	response := map[string]interface{}{
 		"message":   "Status and body not changed",
 		"timestamp": time.Now().UnixNano(),
 	}
-	json.NewEncoder(w).Encode(response)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		log.Printf("encode: %v", err)
+	}
 }
 
-func headerBodyChange(w http.ResponseWriter, r *http.Request) {
+func headerBodyChange(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("X-Transaction-ID", "txn-1")
 	w.Header().Set("Content-Type", "application/json")
 	response := map[string]interface{}{
 		"message":   "Header and body not changed",
 		"timestamp": time.Now().UnixNano(),
 	}
-	json.NewEncoder(w).Encode(response)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		log.Printf("encode: %v", err)
+	}
 }
 
-func statusBodyHeaderChange(w http.ResponseWriter, r *http.Request) {
+func statusBodyHeaderChange(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("X-Transaction-ID", "txn-1")
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -136,17 +157,21 @@ func statusBodyHeaderChange(w http.ResponseWriter, r *http.Request) {
 		"message":   "Status, body, and header not changed",
 		"timestamp": time.Now().UnixNano(),
 	}
-	json.NewEncoder(w).Encode(response)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		log.Printf("encode: %v", err)
+	}
 }
 
-func schemaCompletelyChanged(w http.ResponseWriter, r *http.Request) {
+func schemaCompletelyChanged(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "text/plain")
 	w.WriteHeader(http.StatusOK)
 	response := map[string]interface{}{
 		"message":   "Schema completely not changed",
 		"timestamp": time.Now().UnixNano(),
 	}
-	json.NewEncoder(w).Encode(response)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		log.Printf("encode: %v", err)
+	}
 }
 
 func main() {

--- a/simple-grpc/main.go
+++ b/simple-grpc/main.go
@@ -1,3 +1,4 @@
+// Package main implements a simple gRPC demo server.
 package main
 
 import (
@@ -18,17 +19,17 @@ type server struct {
 }
 
 // 1. Health Check
-func (s *server) Health(ctx context.Context, in *pb.Empty) (*pb.HealthResponse, error) {
+func (s *server) Health(_ context.Context, _ *pb.Empty) (*pb.HealthResponse, error) {
 	return &pb.HealthResponse{Ok: true}, nil
 }
 
 // 2. Simple Hello
-func (s *server) Hello(ctx context.Context, in *pb.Empty) (*pb.HelloResponse, error) {
+func (s *server) Hello(_ context.Context, _ *pb.Empty) (*pb.HelloResponse, error) {
 	return &pb.HelloResponse{Msg: "hello from grpc"}, nil
 }
 
 // 3. Echo
-func (s *server) Echo(ctx context.Context, in *pb.EchoRequest) (*pb.EchoResponse, error) {
+func (s *server) Echo(_ context.Context, in *pb.EchoRequest) (*pb.EchoResponse, error) {
 	msg := in.GetMsg()
 	if msg == "" {
 		msg = "empty"
@@ -37,7 +38,7 @@ func (s *server) Echo(ctx context.Context, in *pb.EchoRequest) (*pb.EchoResponse
 }
 
 // 4. Add Numbers
-func (s *server) Add(ctx context.Context, in *pb.AddRequest) (*pb.AddResponse, error) {
+func (s *server) Add(_ context.Context, in *pb.AddRequest) (*pb.AddResponse, error) {
 	sum := in.GetA() + in.GetB()
 	return &pb.AddResponse{
 		A:   in.GetA(),
@@ -47,14 +48,14 @@ func (s *server) Add(ctx context.Context, in *pb.AddRequest) (*pb.AddResponse, e
 }
 
 // 5. Get Current Time
-func (s *server) GetTime(ctx context.Context, in *pb.Empty) (*pb.TimeResponse, error) {
+func (s *server) GetTime(_ context.Context, _ *pb.Empty) (*pb.TimeResponse, error) {
 	return &pb.TimeResponse{
 		Now: time.Now().UTC().Format(time.RFC3339Nano),
 	}, nil
 }
 
 // 6. Get Resource by ID
-func (s *server) GetResource(ctx context.Context, in *pb.ResourceRequest) (*pb.ResourceResponse, error) {
+func (s *server) GetResource(_ context.Context, in *pb.ResourceRequest) (*pb.ResourceResponse, error) {
 	id := in.GetId()
 	if id == "" {
 		return nil, status.Error(codes.InvalidArgument, "missing id")

--- a/sqs-samples/handler.go
+++ b/sqs-samples/handler.go
@@ -49,14 +49,6 @@ func Upsert(ctx context.Context, u URL) error {
 	return nil
 }
 
-func getJoke(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{"joke": "Why did the golfer bring two pairs of pants? In case he got a hole in one."})
-}
-
-func getExcuse(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{"excuse": "We are not in the same version, hence there is a conflict."})
-}
-
 func getURL(c *gin.Context) {
 	hash := c.Param("param")
 	if hash == "" {

--- a/sqs-samples/main.go
+++ b/sqs-samples/main.go
@@ -1,3 +1,4 @@
+// Package main implements an SQS sample app for Keploy testing.
 package main
 
 import (
@@ -20,7 +21,7 @@ import (
 	"go.uber.org/zap"
 )
 
-var queueUrl = "http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/localstack-queue" // Your SQS queue URL
+var queueURL = "http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/localstack-queue" // Your SQS queue URL
 
 var col *mongo.Collection
 var col2 *mongo.Collection
@@ -57,16 +58,16 @@ func main() {
 	awsCfg, err := config.LoadDefaultConfig(ctx,
 		config.WithRegion("us-east-1"), // LocalStack region (any valid region)
 		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider("dummy", "dummy", "")), // LocalStack doesn't need real credentials
-		config.WithEndpointResolverWithOptions(aws.EndpointResolverWithOptionsFunc(
-			func(service, region string, options ...interface{}) (aws.Endpoint, error) {
+		config.WithEndpointResolverWithOptions(aws.EndpointResolverWithOptionsFunc( //nolint:staticcheck
+			func(service, _ string, _ ...interface{}) (aws.Endpoint, error) { //nolint:staticcheck
 				// Pointing to the LocalStack SQS endpoint
 				if service == sqs.ServiceID {
-					return aws.Endpoint{
-						URL:           queueUrl, // LocalStack SQS endpoint
+					return aws.Endpoint{ //nolint:staticcheck
+						URL:           queueURL, // LocalStack SQS endpoint
 						SigningRegion: "us-east-1",
 					}, nil
 				}
-				return aws.Endpoint{}, fmt.Errorf("unknown service %s", service)
+				return aws.Endpoint{}, fmt.Errorf("unknown service %s", service) //nolint:staticcheck
 			},
 		)),
 	)
@@ -116,7 +117,7 @@ func consumeSQSMessages(ctx context.Context, awsCfg aws.Config) {
 	for {
 		// Receive messages from SQS with WaitTimeSeconds = 4 and MaxMessages = 10
 		resp, err := sqsClient.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
-			QueueUrl:            &queueUrl,
+			QueueUrl:            &queueURL,
 			MaxNumberOfMessages: 10,
 			WaitTimeSeconds:     4,
 		})
@@ -147,7 +148,7 @@ func consumeSQSMessages(ctx context.Context, awsCfg aws.Config) {
 			logger.Info(fmt.Sprintf("Received message: %s\n", *message.Body))
 			// Delete the message after processing it
 			_, err = sqsClient.DeleteMessage(ctx, &sqs.DeleteMessageInput{
-				QueueUrl:      &queueUrl,
+				QueueUrl:      &queueURL,
 				ReceiptHandle: message.ReceiptHandle,
 			})
 			if err != nil {

--- a/sse-preflight/cmd/client/main.go
+++ b/sse-preflight/cmd/client/main.go
@@ -1,3 +1,4 @@
+// Package main is a CORS preflight client for the sse-preflight sample.
 package main
 
 import (
@@ -36,7 +37,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "request failed: %v\n", err)
 		os.Exit(1)
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/sse-preflight/cmd/server/main.go
+++ b/sse-preflight/cmd/server/main.go
@@ -1,3 +1,4 @@
+// Package main is an SSE server with CORS preflight support for Keploy testing.
 package main
 
 import (

--- a/sse-redis/main.go
+++ b/sse-redis/main.go
@@ -1,3 +1,4 @@
+// Package main implements a Redis-backed SSE server for Keploy testing.
 package main
 
 import (
@@ -162,7 +163,6 @@ func handleSSE(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-
 	w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
@@ -180,7 +180,7 @@ func handleSSE(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 	tickerBytes, _ := json.Marshal(tickerData)
-	fmt.Fprintf(w, "event:TICKER\ndata:%s\n\n", tickerBytes)
+	_, _ = fmt.Fprintf(w, "event:TICKER\ndata:%s\n\n", tickerBytes)
 	flusher.Flush()
 
 	for _, msg := range messages {
@@ -200,10 +200,10 @@ func handleSSE(w http.ResponseWriter, r *http.Request) {
 			},
 		}
 		data, _ := json.Marshal(sysData)
-		fmt.Fprintf(w, "event:message\ndata:%s\n\n", data)
+		_, _ = fmt.Fprintf(w, "event:message\ndata:%s\n\n", data)
 		flusher.Flush()
 		time.Sleep(flushDelay)
-		
+
 		// secondary update event (array payload pattern)
 		updateData := []map[string]interface{}{
 			{
@@ -221,7 +221,7 @@ func handleSSE(w http.ResponseWriter, r *http.Request) {
 			},
 		}
 		updateJSON, _ := json.Marshal(updateData)
-		fmt.Fprintf(w, "event:message\ndata:%s\n\n", updateJSON)
+		_, _ = fmt.Fprintf(w, "event:message\ndata:%s\n\n", updateJSON)
 		flusher.Flush()
 		time.Sleep(flushDelay)
 	}
@@ -240,7 +240,7 @@ func handleSSE(w http.ResponseWriter, r *http.Request) {
 		},
 	}
 	finalJSON, _ := json.Marshal(finalData)
-	fmt.Fprintf(w, "event:message\ndata:%s\n\n", finalJSON)
+	_, _ = fmt.Fprintf(w, "event:message\ndata:%s\n\n", finalJSON)
 	flusher.Flush()
 }
 
@@ -308,13 +308,13 @@ func handleMultipart(w http.ResponseWriter, r *http.Request) {
 		event := buildStreamPayload(msg, requestID)
 		data, _ := json.Marshal(event)
 
-		fmt.Fprintf(w, "--%s\r\nContent-Type: application/json\r\n\r\n%s\r\n", boundary, data)
+		_, _ = fmt.Fprintf(w, "--%s\r\nContent-Type: application/json\r\n\r\n%s\r\n", boundary, data)
 		flusher.Flush()
 		if i < len(messages)-1 {
 			time.Sleep(flushDelay)
 		}
 	}
-	fmt.Fprintf(w, "--%s--\r\n", boundary)
+	_, _ = fmt.Fprintf(w, "--%s--\r\n", boundary)
 	flusher.Flush()
 }
 

--- a/tls-dadjoke/main.go
+++ b/tls-dadjoke/main.go
@@ -1,3 +1,4 @@
+// Package main provides a TLS-enabled dad joke HTTP server for Keploy testing.
 package main
 
 import (
@@ -8,7 +9,7 @@ import (
 )
 
 // jokeHandler is the function that handles requests to the /joke endpoint.
-func jokeHandler(w http.ResponseWriter, r *http.Request) {
+func jokeHandler(w http.ResponseWriter, _ *http.Request) {
 	// The API URL for icanhazdadjoke.com
 	jokeAPIURL := "https://icanhazdadjoke.com/"
 
@@ -36,7 +37,7 @@ func jokeHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Ensure the response body is closed when the function returns.
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck
 
 	// Check if the request to the joke API was successful.
 	if resp.StatusCode != http.StatusOK {
@@ -57,7 +58,9 @@ func jokeHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	// Write the joke (which is already in JSON format) to our response.
-	w.Write(body)
+	if _, err = w.Write(body); err != nil {
+		log.Printf("Error writing response: %v", err)
+	}
 }
 
 func main() {


### PR DESCRIPTION
## Summary

18 sample apps with a \`go.mod\` were not included in the \`golangci-lint\` workflow's static matrix. The \`build\` workflow also used Go 1.22, which was too old to build several recently added modules (some require Go 1.24–1.26).

### What was missing

The lint matrix had 17 apps hardcoded. The following 18 apps existed in the repo but had no lint coverage:
\`connect-tunnel\`, \`dns-dedup\`, \`dns-mock-test\`, \`go-dedup\`, \`go-docker-timefreeze\`, \`go-memory-load\`, \`go-redis\`, \`grpc-mongo\`, \`grpc-secret\`, \`http-postgres\`, \`http-sse\`, \`proxy-stress-test\`, \`risk-profile\`, \`simple-grpc\`, \`sqs-samples\`, \`sse-preflight\`, \`sse-redis\`, \`tls-dadjoke\`.

### How CI coverage was fixed

**build.yml**
- Upgraded to `actions/checkout@v4` and `actions/setup-go@v5` with `go-version: stable`
- Removed `SKIP_DIRS` for `dns-mock-test` — stable Go covers all modules

**golangci-lint.yml**
- Upgraded to `actions/setup-go@v5` with `go-version: stable` (needed for modules requiring Go 1.24–1.26)
- Added all 18 missing apps to the matrix (alphabetically sorted, all 35 apps now covered)

### Pre-existing lint issues fixed

To get the newly added apps to pass `golangci-lint v1.63.4`, the minimum required fixes were made:
- Added package doc comments to un-documented main packages
- Fixed `errcheck`: proper error handling for `json.Encode`, `fmt.Fprintf`, and `//nolint:errcheck` for deferred cleanup calls (`Body.Close`, `rows.Close`, `tx.Rollback`, `db.Close`)
- Fixed `unused-parameter`: renamed unused `r *http.Request` and `ctx context.Context` parameters to `_`
- Fixed `blank-imports`: added driver justification comments
- Fixed `gofmt`: reformatted `sse-redis/main.go`, `risk-profile/main.go`, `proxy-stress-test/main.go`
- Fixed `SA1019`: suppressed `grpc.DialContext`/`aws.Endpoint` deprecated usage with `//nolint:staticcheck`
- Fixed `redefines-builtin-id`: renamed `min()` → `minInt()` in `grpc-secret`
- Fixed `var-naming`: renamed `queueUrl` → `queueURL` in `sqs-samples`
- Fixed `unused`: removed unused `getJoke` and `getExcuse` functions in `sqs-samples`
- Fixed `S1011` (gosimple): replaced inner loop with `append(txts, txt.Txt...)` in `dns-mock-test`
- Fixed deprecated `rand.Seed` in `go-dedup` with `rand.New(rand.NewSource(...))`

### Validation

All 35 apps (17 existing + 18 new) verified locally with `golangci-lint v1.63.4` and `go build ./...` before opening this PR.

## Sanity check — integration tests

Two sanity check PRs were opened against this branch to verify the lint fixes don't break any integration tests:

- **keploy/keploy#4068** — all Go integration jobs pass ✅ (https://github.com/keploy/keploy/actions/runs/24505218144)
- **keploy/enterprise#1866** — all relevant Woodpecker pipelines pass ✅ (https://ci.keploy.com/repos/1/pipeline/2406/1)

The only pending jobs in those PRs (`http-pokeapi` WSL in keploy and `kafka-ecommerce` in enterprise) are unrelated to the apps modified here.

## Test plan

- [x] All `golangci-lint` matrix jobs pass (35 apps)
- [x] `Build Go Sample Projects` workflow passes
- [x] Integration tests pass in keploy/keploy and keploy/enterprise sanity check PRs