### PR TITLE
feat(postgres-wire-features): add Postgres v3 wire-protocol sample

### DIFF
--- a/postgres-wire-features/.gitignore
+++ b/postgres-wire-features/.gitignore
@@ -1,0 +1,5 @@
+keploy/
+keploy.yml
+keploy-logs.txt
+server
+*.log

--- a/postgres-wire-features/.gitignore
+++ b/postgres-wire-features/.gitignore
@@ -2,4 +2,5 @@ keploy/
 keploy.yml
 keploy-logs.txt
 server
+postgres-wire-features
 *.log

--- a/postgres-wire-features/Dockerfile
+++ b/postgres-wire-features/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.24-alpine AS builder
+
+WORKDIR /app
+COPY go.mod ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o server .
+
+FROM alpine:3.19
+WORKDIR /app
+COPY --from=builder /app/server .
+EXPOSE 8080
+CMD ["./server"]

--- a/postgres-wire-features/README.md
+++ b/postgres-wire-features/README.md
@@ -1,0 +1,98 @@
+# postgres-wire-features
+
+A small Go HTTP service that exercises a broad set of PostgreSQL wire-protocol features in one place — designed as a Keploy sample for recording and replaying Postgres interactions that go beyond plain `SELECT` / `INSERT`.
+
+The service speaks the Postgres v3 frontend/backend protocol directly over a TCP socket (pure stdlib — no driver). That makes the recorded traffic a faithful representation of what Keploy sees on the wire, which matters for features like `COPY` whose payload is a stream of `CopyData` / `CopyDone` messages that driver libraries often abstract away.
+
+## What it covers
+
+A single call to `GET /run/all` walks through ten scenarios in order:
+
+| Scenario | Statements |
+| --- | --- |
+| `setup` | `DROP TABLE`, `CREATE TABLE`, `INSERT`, `CREATE TABLE IF NOT EXISTS` |
+| `dml` | `INSERT … ON CONFLICT DO UPDATE`, `UPDATE`, `DELETE`, `MERGE` |
+| `catalog-cte` | `WITH … SELECT FROM pg_catalog.pg_class` |
+| `catalog-sub` | `SELECT … FROM (SELECT …) AS s` |
+| `catalog-setop` | `SELECT … UNION SELECT …` |
+| `copy` | `TRUNCATE`, `COPY … FROM STDIN`, `COPY … TO STDOUT` |
+| `prepare` | `PREPARE`, `EXECUTE`, `DEALLOCATE` |
+| `cursor` | `BEGIN`, `DECLARE CURSOR`, `FETCH`×2, `CLOSE`, `COMMIT` |
+| `admin` | `ANALYZE`, `REINDEX`, `LOCK TABLE`, `DO $$ … $$`, `CREATE PROCEDURE`, `CALL` |
+| `validation-ping` | `SELECT 'ok'`, `SELECT true`, `SELECT NULL`, `SELECT 1` |
+
+Each scenario is also reachable individually at `GET /case/<name>`. The response is JSON: per-statement `commands` (the Postgres command tag, e.g. `COPY 2`, `SELECT 1`), `rows`, and for `COPY TO STDOUT` a `copyData` array of the raw tab-separated rows.
+
+## Endpoints
+
+- `GET /health` → `200 ok`
+- `GET /run/all` → run every scenario in order, return the combined result
+- `GET /case/<name>` → run one scenario (see table above)
+
+## Prerequisites
+
+- Go `1.24+`
+- Docker and Docker Compose
+- Keploy CLI
+
+Install Keploy:
+
+```bash
+curl --silent -O -L https://keploy.io/install.sh
+source install.sh
+```
+
+## Setup
+
+```bash
+git clone https://github.com/keploy/samples-go.git
+cd samples-go/postgres-wire-features
+go mod download
+```
+
+## Run with Docker
+
+```bash
+docker compose up --build
+```
+
+The API will be available at `http://localhost:8080`.
+
+## Record Testcases with Keploy
+
+```bash
+keploy record -c "docker compose up" --container-name api --delay 10
+```
+
+In another terminal:
+
+```bash
+./test.sh
+```
+
+Keploy writes the recorded HTTP tests and Postgres mocks under `keploy/`.
+
+## Replay Recorded Tests
+
+```bash
+keploy test -c "docker compose up" --container-name api --delay 20
+```
+
+## Run Natively
+
+Start Postgres yourself (e.g. `docker run -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres:16-alpine`) and then:
+
+```bash
+PGHOST=127.0.0.1 PGPORT=5432 PGUSER=postgres PGPASSWORD=postgres PGDATABASE=postgres go run .
+```
+
+## Environment variables
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `ADDR` | `:8080` | Listen address for the HTTP server |
+| `PGHOST` | `127.0.0.1` | Postgres host |
+| `PGPORT` | `5432` | Postgres port |
+| `PGUSER` | `postgres` | Postgres user |
+| `PGPASSWORD` | _(empty)_ | Postgres password |
+| `PGDATABASE` | `postgres` | Postgres database |

--- a/postgres-wire-features/README.md
+++ b/postgres-wire-features/README.md
@@ -6,7 +6,7 @@ The service speaks the Postgres v3 frontend/backend protocol directly over a TCP
 
 ## What it covers
 
-A single call to `GET /run/all` walks through ten scenarios in order:
+A single call to `GET /run/all` walks through twelve scenarios in order:
 
 | Scenario | Statements |
 | --- | --- |
@@ -20,6 +20,8 @@ A single call to `GET /run/all` walks through ten scenarios in order:
 | `cursor` | `BEGIN`, `DECLARE CURSOR`, `FETCH`×2, `CLOSE`, `COMMIT` |
 | `admin` | `ANALYZE`, `REINDEX`, `LOCK TABLE`, `DO $$ … $$`, `CREATE PROCEDURE`, `CALL` |
 | `validation-ping` | `SELECT 'ok'`, `SELECT true`, `SELECT NULL`, `SELECT 1` |
+| `multistatement` | `BEGIN; SELECT 1 AS a; SELECT 2 AS b; COMMIT` sent as a **single** simple-Query packet (exercises multi-statement split) |
+| `empty-query` | simple-Query packet with empty SQL body (exercises `EmptyQueryResponse` / ghost-event suppression) |
 
 Each scenario is also reachable individually at `GET /case/<name>`. The response is JSON: per-statement `commands` (the Postgres command tag, e.g. `COPY 2`, `SELECT 1`), `rows`, and for `COPY TO STDOUT` a `copyData` array of the raw tab-separated rows.
 
@@ -71,6 +73,20 @@ In another terminal:
 ```
 
 Keploy writes the recorded HTTP tests and Postgres mocks under `keploy/`.
+
+## Validate recorded mocks
+
+Run the assertions script after recording to verify v3 protocol invariants:
+
+```bash
+./assertions.sh keploy
+```
+
+It fails the pipeline if it sees any of:
+- an invocation with `class: UNKNOWN`
+- an invocation with an empty `sqlNormalized` (ghost event)
+- the `multistatement` batch collapsed into fewer than four invocations
+- all fields encoded as `!!binary` with no readable SQL in the mocks
 
 ## Replay Recorded Tests
 

--- a/postgres-wire-features/assertions.sh
+++ b/postgres-wire-features/assertions.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Post-record assertions for the v3 Postgres recorder against the
+# postgres-wire-features sample. Exits non-zero on the first violation
+# so the Woodpecker step shows a clean pass/fail.
+#
+# These assertions codify invariants that the *fixed* v3 recorder must
+# hold. A broken v3 (for example origin/main today) produces mocks that
+# violate at least one of them: empty-query ghost invocations with
+# class=UNKNOWN, or a multi-statement Q packet collapsed into one
+# invocation, or bind values emitted as base64 when the raw bytes are
+# valid UTF-8 text.
+#
+# Usage: ./assertions.sh [mocks_dir]
+#   default mocks_dir: ./keploy
+
+set -euo pipefail
+
+MOCKS_DIR="${1:-./keploy}"
+
+if [[ ! -d "$MOCKS_DIR" ]]; then
+	echo "assertions: mocks directory not found at $MOCKS_DIR" >&2
+	exit 2
+fi
+
+# Collect every mocks.yaml beneath $MOCKS_DIR. Keploy writes one
+# mocks.yaml per test-set.
+mapfile -t MOCK_FILES < <(find "$MOCKS_DIR" -type f -name 'mocks.yaml' | sort)
+if [[ ${#MOCK_FILES[@]} -eq 0 ]]; then
+	echo "assertions: no mocks.yaml found under $MOCKS_DIR" >&2
+	exit 2
+fi
+
+echo "assertions: scanning ${#MOCK_FILES[@]} mocks.yaml file(s) under $MOCKS_DIR"
+
+fail() {
+	echo "FAIL: $1" >&2
+	exit 1
+}
+
+pass() {
+	echo "PASS: $1"
+}
+
+# ------------------------------------------------------------------
+# Invariant 1: no invocation is classified as UNKNOWN.
+# Origin/main emits class=UNKNOWN for ghost events and for statements
+# its classifier does not recognize.
+# ------------------------------------------------------------------
+unknown_count=0
+for f in "${MOCK_FILES[@]}"; do
+	c=$(grep -c -E '^\s*class:\s*UNKNOWN\s*$' "$f" || true)
+	unknown_count=$((unknown_count + c))
+done
+if [[ $unknown_count -ne 0 ]]; then
+	echo "--- first few UNKNOWN hits ---"
+	grep -n -E '^\s*class:\s*UNKNOWN\s*$' "${MOCK_FILES[@]}" | head -n 10 || true
+	fail "found $unknown_count invocation(s) with class: UNKNOWN"
+fi
+pass "no class: UNKNOWN invocations"
+
+# ------------------------------------------------------------------
+# Invariant 2: no ghost invocation with an empty sqlNormalized.
+# A correct recorder suppresses EmptyQueryResponse paths instead of
+# emitting an invocation shell with sqlNormalized: "".
+# ------------------------------------------------------------------
+empty_sql_count=0
+for f in "${MOCK_FILES[@]}"; do
+	# Match both   sqlNormalized: ""    and   sqlNormalized:
+	c=$(grep -c -E '^\s*sqlNormalized:\s*("")?\s*$' "$f" || true)
+	empty_sql_count=$((empty_sql_count + c))
+done
+if [[ $empty_sql_count -ne 0 ]]; then
+	echo "--- first few empty sqlNormalized hits ---"
+	grep -n -E '^\s*sqlNormalized:\s*("")?\s*$' "${MOCK_FILES[@]}" | head -n 10 || true
+	fail "found $empty_sql_count invocation(s) with empty sqlNormalized (ghost event)"
+fi
+pass "no empty sqlNormalized invocations"
+
+# ------------------------------------------------------------------
+# Invariant 3: the multistatement Q packet produced distinct
+# invocations for each of its four statements.
+#
+# The sample sends `BEGIN; SELECT 1 AS a; SELECT 2 AS b; COMMIT`
+# as a single simple-Query packet. A recorder that splits the batch
+# with pg_query emits four invocations with distinct sqlNormalized
+# fragments; a recorder that tracks per-packet emits one.
+# ------------------------------------------------------------------
+begin_count=0
+commit_count=0
+select_a_count=0
+select_b_count=0
+for f in "${MOCK_FILES[@]}"; do
+	begin_count=$((begin_count + $(grep -c -E '^\s*sqlNormalized:\s*["'"'"']?BEGIN["'"'"']?\s*$' "$f" || true)))
+	commit_count=$((commit_count + $(grep -c -E '^\s*sqlNormalized:\s*["'"'"']?COMMIT["'"'"']?\s*$' "$f" || true)))
+	select_a_count=$((select_a_count + $(grep -c -E 'sqlNormalized:.*SELECT\s+\$1\s+AS\s+a' "$f" || true)))
+	select_b_count=$((select_b_count + $(grep -c -E 'sqlNormalized:.*SELECT\s+\$1\s+AS\s+b' "$f" || true)))
+done
+if [[ $begin_count -lt 1 || $commit_count -lt 1 || $select_a_count -lt 1 || $select_b_count -lt 1 ]]; then
+	echo "  BEGIN=$begin_count COMMIT=$commit_count SELECT_a=$select_a_count SELECT_b=$select_b_count"
+	fail "multistatement Q packet was not split into 4 invocations (expected >=1 each of BEGIN, COMMIT, SELECT ... AS a, SELECT ... AS b)"
+fi
+pass "multistatement Q packet split into distinct invocations (BEGIN=$begin_count, COMMIT=$commit_count, SELECT a=$select_a_count, SELECT b=$select_b_count)"
+
+# ------------------------------------------------------------------
+# Invariant 4: text bind values are emitted as plain YAML strings
+# (not wrapped in a !!binary tag) when the raw bytes are UTF-8 safe.
+# The prepare/execute scenario's bind contains ASCII integers, and
+# the COPY IN scenario's payload is ASCII text — both should survive
+# as readable strings.
+# ------------------------------------------------------------------
+binary_tag_count=0
+for f in "${MOCK_FILES[@]}"; do
+	c=$(grep -c -E '!!binary' "$f" || true)
+	binary_tag_count=$((binary_tag_count + c))
+done
+echo "  info: !!binary tag occurrences across mocks = $binary_tag_count"
+# We don't fail on this count (truly-binary values like lsn/xid bytes
+# legitimately round-trip as !!binary); instead assert that a known-
+# textual bind ('seed-a' from COPY IN) appears as a plain string.
+if ! grep -R -l -E "seed-a" "$MOCKS_DIR" >/dev/null 2>&1; then
+	# seed-a might only appear post-COPY; tolerate its absence, but
+	# require that at least one readable SQL fragment is present so
+	# we know the file isn't entirely base64-encoded.
+	if ! grep -R -l -E 'sqlNormalized:.*SELECT' "$MOCKS_DIR" >/dev/null 2>&1; then
+		fail "no readable sqlNormalized values found — every field may be base64 encoded"
+	fi
+fi
+pass "readable text fields are present in mocks (not exclusively base64)"
+
+echo "assertions: all invariants satisfied"

--- a/postgres-wire-features/docker-compose.yml
+++ b/postgres-wire-features/docker-compose.yml
@@ -5,6 +5,13 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: postgres
+      # Force trust auth (code 0). Postgres 16 defaults to scram-sha-256
+      # (code 10), which this sample's raw-v3 client does not speak — we
+      # only implement code 0 / 3 / 5. This keeps auth on a path the
+      # sample can actually complete so the downstream Postgres wire
+      # surface (CopyData, cursors, PREPARE/EXECUTE, etc.) is what the
+      # record/replay cycle is actually exercising.
+      POSTGRES_HOST_AUTH_METHOD: trust
     ports:
       - "5433:5432"
     volumes:

--- a/postgres-wire-features/docker-compose.yml
+++ b/postgres-wire-features/docker-compose.yml
@@ -1,0 +1,33 @@
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+    ports:
+      - "5433:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 2s
+      timeout: 5s
+      retries: 5
+
+  api:
+    build: .
+    ports:
+      - "8080:8080"
+    environment:
+      PGHOST: db
+      PGPORT: "5432"
+      PGUSER: postgres
+      PGPASSWORD: postgres
+      PGDATABASE: postgres
+    depends_on:
+      db:
+        condition: service_healthy
+
+volumes:
+  pgdata:

--- a/postgres-wire-features/docker-compose.yml
+++ b/postgres-wire-features/docker-compose.yml
@@ -3,17 +3,20 @@ services:
     image: postgres:16-alpine
     environment:
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
       POSTGRES_DB: postgres
       # Force trust auth (code 0). Postgres 16 defaults to scram-sha-256
       # (code 10), which this sample's raw-v3 client does not speak — we
       # only implement code 0 / 3 / 5. This keeps auth on a path the
       # sample can actually complete so the downstream Postgres wire
       # surface (CopyData, cursors, PREPARE/EXECUTE, etc.) is what the
-      # record/replay cycle is actually exercising.
+      # record/replay cycle is actually exercising. With trust auth the
+      # server never requests a password, so POSTGRES_PASSWORD/PGPASSWORD
+      # are intentionally omitted to avoid implying otherwise.
       POSTGRES_HOST_AUTH_METHOD: trust
     ports:
-      - "5433:5432"
+      # Bind to loopback only so the trust-auth Postgres isn't reachable
+      # from other hosts on the developer's network.
+      - "127.0.0.1:5433:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
@@ -30,7 +33,6 @@ services:
       PGHOST: db
       PGPORT: "5432"
       PGUSER: postgres
-      PGPASSWORD: postgres
       PGDATABASE: postgres
     depends_on:
       db:

--- a/postgres-wire-features/go.mod
+++ b/postgres-wire-features/go.mod
@@ -1,0 +1,3 @@
+module postgres-wire-features
+
+go 1.24

--- a/postgres-wire-features/main.go
+++ b/postgres-wire-features/main.go
@@ -17,9 +17,28 @@ import (
 	"time"
 )
 
+// opTimeout bounds a single Postgres operation (startup handshake or a
+// simple-Query round trip). It protects the HTTP handler from hanging
+// indefinitely on a stalled or half-open TCP connection: each operation
+// sets a deadline on the underlying net.Conn, so `io.ReadFull` inside
+// readMessage returns a timeout error instead of blocking forever.
+const opTimeout = 30 * time.Second
+
 type pgClient struct {
 	conn net.Conn
 	user string
+}
+
+// setOpDeadline arms a per-operation deadline on the connection. Call
+// clearOpDeadline (typically via defer) to remove it so the deadline
+// doesn't leak into the next operation on a shared connection (as used
+// by /run/all).
+func (c *pgClient) setOpDeadline() error {
+	return c.conn.SetDeadline(time.Now().Add(opTimeout))
+}
+
+func (c *pgClient) clearOpDeadline() {
+	_ = c.conn.SetDeadline(time.Time{})
 }
 
 type queryResult struct {
@@ -324,6 +343,11 @@ func dialPostgres() (*pgClient, error) {
 }
 
 func (c *pgClient) startup(user, db, password string) error {
+	if err := c.setOpDeadline(); err != nil {
+		return err
+	}
+	defer c.clearOpDeadline()
+
 	var body bytes.Buffer
 	_ = binary.Write(&body, binary.BigEndian, int32(196608))
 	writeCString(&body, "user")
@@ -370,7 +394,11 @@ func (c *pgClient) startup(user, db, password string) error {
 					return err
 				}
 			default:
-				return fmt.Errorf("unsupported postgres authentication code %d", code)
+				// Postgres 16 defaults to scram-sha-256 (code 10), which
+				// this raw-v3 client does not implement. Surface a hint
+				// so users can fix local runs without digging through
+				// protocol docs.
+				return fmt.Errorf("unsupported postgres authentication code %d; this client only speaks codes 0 (trust), 3 (cleartext), and 5 (md5). Postgres 16 defaults to scram-sha-256 (code 10); configure the server with POSTGRES_HOST_AUTH_METHOD=trust or md5 (or a pg_hba.conf entry that selects one of those) for this sample", code)
 			}
 		case 'S', 'K':
 		case 'Z':
@@ -391,6 +419,11 @@ func (c *pgClient) sendPassword(password string) error {
 
 func (c *pgClient) simpleQuery(sql, copyInput string) (queryResult, error) {
 	res := queryResult{SQL: oneLine(sql)}
+	if err := c.setOpDeadline(); err != nil {
+		return res, err
+	}
+	defer c.clearOpDeadline()
+
 	var body bytes.Buffer
 	writeCString(&body, sql)
 	if err := c.writeMessage('Q', body.Bytes()); err != nil {

--- a/postgres-wire-features/main.go
+++ b/postgres-wire-features/main.go
@@ -42,7 +42,7 @@ func main() {
 		_, _ = w.Write([]byte("ok\n"))
 	})
 
-	cases := map[string]func() ([]queryResult, error){
+	cases := map[string]func(*pgClient) ([]queryResult, error){
 		"setup":           runSetup,
 		"dml":             runDML,
 		"catalog-cte":     runCatalogCTE,
@@ -58,10 +58,15 @@ func main() {
 	for name, fn := range cases {
 		name, fn := name, fn
 		mux.HandleFunc("/case/"+name, func(w http.ResponseWriter, _ *http.Request) {
-			writeCase(w, name, fn)
+			writeCase(w, name, func() ([]queryResult, error) { return withClient(fn) })
 		})
 	}
 
+	// /run/all walks every scenario on a SINGLE Postgres connection. Opening
+	// a fresh connection per scenario pushes Keploy's docker-mode proxy into
+	// a back-to-back connect/close regime where it drops handshakes; sharing
+	// one connection keeps the v3 wire surface exercised without triggering
+	// that unrelated instability.
 	mux.HandleFunc("/run/all", func(w http.ResponseWriter, _ *http.Request) {
 		order := []string{
 			"setup",
@@ -77,8 +82,16 @@ func main() {
 		}
 		results := make([]caseResult, 0, len(order))
 		status := http.StatusOK
+
+		c, err := dialPostgres()
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, caseResult{Name: "dial", Error: err.Error()})
+			return
+		}
+		defer c.conn.Close()
+
 		for _, name := range order {
-			res, err := cases[name]()
+			res, err := cases[name](c)
 			item := caseResult{Name: name, Result: res}
 			if err != nil {
 				item.Error = err.Error()
@@ -122,148 +135,128 @@ func withClient(fn func(*pgClient) ([]queryResult, error)) ([]queryResult, error
 	return fn(c)
 }
 
-func runSetup() ([]queryResult, error) {
-	return withClient(func(c *pgClient) ([]queryResult, error) {
-		return runQueries(c,
-			`DROP TABLE IF EXISTS gap_items`,
-			`CREATE TABLE gap_items (id SERIAL PRIMARY KEY, name TEXT NOT NULL)`,
-			`INSERT INTO gap_items(name) VALUES ('seed-a'), ('seed-b')`,
-			`CREATE TABLE IF NOT EXISTS flyway_schema_history (
-				installed_rank INT PRIMARY KEY,
-				version TEXT,
-				description TEXT,
-				type TEXT,
-				script TEXT,
-				checksum INT,
-				installed_by TEXT,
-				installed_on TIMESTAMP DEFAULT now(),
-				execution_time INT,
-				success BOOLEAN
-			)`,
-		)
-	})
+func runSetup(c *pgClient) ([]queryResult, error) {
+	return runQueries(c,
+		`DROP TABLE IF EXISTS gap_items`,
+		`CREATE TABLE gap_items (id SERIAL PRIMARY KEY, name TEXT NOT NULL)`,
+		`INSERT INTO gap_items(name) VALUES ('seed-a'), ('seed-b')`,
+		`CREATE TABLE IF NOT EXISTS flyway_schema_history (
+			installed_rank INT PRIMARY KEY,
+			version TEXT,
+			description TEXT,
+			type TEXT,
+			script TEXT,
+			checksum INT,
+			installed_by TEXT,
+			installed_on TIMESTAMP DEFAULT now(),
+			execution_time INT,
+			success BOOLEAN
+		)`,
+	)
 }
 
-func runDML() ([]queryResult, error) {
-	return withClient(func(c *pgClient) ([]queryResult, error) {
-		return runQueries(c,
-			`INSERT INTO flyway_schema_history
-				(installed_rank, version, description, type, script, checksum, installed_by, execution_time, success)
-			 VALUES (1, '1', 'v3 dml classifier repro', 'SQL', 'V1__gap.sql', 42, 'gap-app', 7, true)
-			 ON CONFLICT (installed_rank) DO UPDATE SET checksum = EXCLUDED.checksum`,
-			`UPDATE gap_items SET name = name || '-updated' WHERE id = 1`,
-			`DELETE FROM gap_items WHERE name = 'never-present'`,
-			`MERGE INTO gap_items AS target
-			 USING (VALUES (2, 'seed-b-merged')) AS src(id, name)
-			 ON target.id = src.id
-			 WHEN MATCHED THEN UPDATE SET name = src.name
-			 WHEN NOT MATCHED THEN INSERT (id, name) VALUES (src.id, src.name)`,
-		)
-	})
+func runDML(c *pgClient) ([]queryResult, error) {
+	return runQueries(c,
+		`INSERT INTO flyway_schema_history
+			(installed_rank, version, description, type, script, checksum, installed_by, execution_time, success)
+		 VALUES (1, '1', 'v3 dml classifier repro', 'SQL', 'V1__gap.sql', 42, 'gap-app', 7, true)
+		 ON CONFLICT (installed_rank) DO UPDATE SET checksum = EXCLUDED.checksum`,
+		`UPDATE gap_items SET name = name || '-updated' WHERE id = 1`,
+		`DELETE FROM gap_items WHERE name = 'never-present'`,
+		`MERGE INTO gap_items AS target
+		 USING (VALUES (2, 'seed-b-merged')) AS src(id, name)
+		 ON target.id = src.id
+		 WHEN MATCHED THEN UPDATE SET name = src.name
+		 WHEN NOT MATCHED THEN INSERT (id, name) VALUES (src.id, src.name)`,
+	)
 }
 
-func runCatalogCTE() ([]queryResult, error) {
-	return withClient(func(c *pgClient) ([]queryResult, error) {
-		return runQueries(c,
-			`WITH catalog_rels AS (
-				SELECT oid, relname FROM pg_catalog.pg_class WHERE relname IN ('pg_class', 'pg_type')
-			 )
-			 SELECT relname FROM catalog_rels ORDER BY relname`,
-		)
-	})
+func runCatalogCTE(c *pgClient) ([]queryResult, error) {
+	return runQueries(c,
+		`WITH catalog_rels AS (
+			SELECT oid, relname FROM pg_catalog.pg_class WHERE relname IN ('pg_class', 'pg_type')
+		 )
+		 SELECT relname FROM catalog_rels ORDER BY relname`,
+	)
 }
 
-func runCatalogSubselect() ([]queryResult, error) {
-	return withClient(func(c *pgClient) ([]queryResult, error) {
-		return runQueries(c,
-			`SELECT relname
-			 FROM (SELECT relname FROM pg_catalog.pg_class WHERE relname = 'pg_class') AS catalog_subquery`,
-		)
-	})
+func runCatalogSubselect(c *pgClient) ([]queryResult, error) {
+	return runQueries(c,
+		`SELECT relname
+		 FROM (SELECT relname FROM pg_catalog.pg_class WHERE relname = 'pg_class') AS catalog_subquery`,
+	)
 }
 
-func runCatalogSetOp() ([]queryResult, error) {
-	return withClient(func(c *pgClient) ([]queryResult, error) {
-		return runQueries(c,
-			`SELECT relname FROM pg_catalog.pg_class WHERE relname = 'pg_class'
-			 UNION
-			 SELECT relname FROM pg_catalog.pg_class WHERE relname = 'pg_type'
-			 ORDER BY relname`,
-		)
-	})
+func runCatalogSetOp(c *pgClient) ([]queryResult, error) {
+	return runQueries(c,
+		`SELECT relname FROM pg_catalog.pg_class WHERE relname = 'pg_class'
+		 UNION
+		 SELECT relname FROM pg_catalog.pg_class WHERE relname = 'pg_type'
+		 ORDER BY relname`,
+	)
 }
 
-func runCopy() ([]queryResult, error) {
-	return withClient(func(c *pgClient) ([]queryResult, error) {
-		var all []queryResult
-		setup, err := runQueries(c, `TRUNCATE gap_items RESTART IDENTITY`)
-		if err != nil {
-			return all, err
-		}
-		all = append(all, setup...)
+func runCopy(c *pgClient) ([]queryResult, error) {
+	var all []queryResult
+	setup, err := runQueries(c, `TRUNCATE gap_items RESTART IDENTITY`)
+	if err != nil {
+		return all, err
+	}
+	all = append(all, setup...)
 
-		in, err := c.simpleQuery(`COPY gap_items(name) FROM STDIN`, "copy-a\ncopy-b\n")
-		if err != nil {
-			return all, err
-		}
-		all = append(all, in)
+	in, err := c.simpleQuery(`COPY gap_items(name) FROM STDIN`, "copy-a\ncopy-b\n")
+	if err != nil {
+		return all, err
+	}
+	all = append(all, in)
 
-		out, err := c.simpleQuery(`COPY (SELECT id, name FROM gap_items ORDER BY id) TO STDOUT`, "")
-		if err != nil {
-			return all, err
-		}
-		all = append(all, out)
-		return all, nil
-	})
+	out, err := c.simpleQuery(`COPY (SELECT id, name FROM gap_items ORDER BY id) TO STDOUT`, "")
+	if err != nil {
+		return all, err
+	}
+	all = append(all, out)
+	return all, nil
 }
 
-func runPrepareExecute() ([]queryResult, error) {
-	return withClient(func(c *pgClient) ([]queryResult, error) {
-		return runQueries(c,
-			`PREPARE gap_lookup(int) AS SELECT name FROM gap_items WHERE id = $1`,
-			`EXECUTE gap_lookup(1)`,
-			`DEALLOCATE gap_lookup`,
-		)
-	})
+func runPrepareExecute(c *pgClient) ([]queryResult, error) {
+	return runQueries(c,
+		`PREPARE gap_lookup(int) AS SELECT name FROM gap_items WHERE id = $1`,
+		`EXECUTE gap_lookup(1)`,
+		`DEALLOCATE gap_lookup`,
+	)
 }
 
-func runCursor() ([]queryResult, error) {
-	return withClient(func(c *pgClient) ([]queryResult, error) {
-		return runQueries(c,
-			`BEGIN`,
-			`DECLARE gap_cursor CURSOR FOR SELECT id, name FROM gap_items ORDER BY id`,
-			`FETCH 1 FROM gap_cursor`,
-			`FETCH 1 FROM gap_cursor`,
-			`CLOSE gap_cursor`,
-			`COMMIT`,
-		)
-	})
+func runCursor(c *pgClient) ([]queryResult, error) {
+	return runQueries(c,
+		`BEGIN`,
+		`DECLARE gap_cursor CURSOR FOR SELECT id, name FROM gap_items ORDER BY id`,
+		`FETCH 1 FROM gap_cursor`,
+		`FETCH 1 FROM gap_cursor`,
+		`CLOSE gap_cursor`,
+		`COMMIT`,
+	)
 }
 
-func runAdminStatements() ([]queryResult, error) {
-	return withClient(func(c *pgClient) ([]queryResult, error) {
-		return runQueries(c,
-			`ANALYZE gap_items`,
-			`REINDEX TABLE gap_items`,
-			`BEGIN`,
-			`LOCK TABLE gap_items IN ACCESS SHARE MODE`,
-			`COMMIT`,
-			`DO $$ BEGIN PERFORM 1; END $$`,
-			`CREATE OR REPLACE PROCEDURE gap_noop() LANGUAGE plpgsql AS $$ BEGIN PERFORM 1; END $$`,
-			`CALL gap_noop()`,
-		)
-	})
+func runAdminStatements(c *pgClient) ([]queryResult, error) {
+	return runQueries(c,
+		`ANALYZE gap_items`,
+		`REINDEX TABLE gap_items`,
+		`BEGIN`,
+		`LOCK TABLE gap_items IN ACCESS SHARE MODE`,
+		`COMMIT`,
+		`DO $$ BEGIN PERFORM 1; END $$`,
+		`CREATE OR REPLACE PROCEDURE gap_noop() LANGUAGE plpgsql AS $$ BEGIN PERFORM 1; END $$`,
+		`CALL gap_noop()`,
+	)
 }
 
-func runValidationPing() ([]queryResult, error) {
-	return withClient(func(c *pgClient) ([]queryResult, error) {
-		return runQueries(c,
-			`SELECT 'ok'`,
-			`SELECT true`,
-			`SELECT NULL`,
-			`SELECT 1`,
-		)
-	})
+func runValidationPing(c *pgClient) ([]queryResult, error) {
+	return runQueries(c,
+		`SELECT 'ok'`,
+		`SELECT true`,
+		`SELECT NULL`,
+		`SELECT 1`,
+	)
 }
 
 func runQueries(c *pgClient, queries ...string) ([]queryResult, error) {

--- a/postgres-wire-features/main.go
+++ b/postgres-wire-features/main.go
@@ -53,6 +53,8 @@ func main() {
 		"cursor":          runCursor,
 		"admin":           runAdminStatements,
 		"validation-ping": runValidationPing,
+		"multistatement":  runMultiStatement,
+		"empty-query":     runEmptyQuery,
 	}
 
 	for name, fn := range cases {
@@ -79,6 +81,8 @@ func main() {
 			"cursor",
 			"admin",
 			"validation-ping",
+			"multistatement",
+			"empty-query",
 		}
 		results := make([]caseResult, 0, len(order))
 		status := http.StatusOK
@@ -259,6 +263,34 @@ func runValidationPing(c *pgClient) ([]queryResult, error) {
 	)
 }
 
+// runMultiStatement sends a semicolon-separated batch of four statements
+// as a SINGLE simple-Query ('Q') packet. The server answers with four
+// CommandComplete responses (plus interleaved RowDescription/DataRow for
+// the two SELECTs) before a single ReadyForQuery. A v3 recorder that
+// tracks invocations per-packet rather than per-statement under-counts
+// the result to one invocation; a correct recorder splits the batch with
+// pg_query and emits four invocations (one per statement).
+func runMultiStatement(c *pgClient) ([]queryResult, error) {
+	res, err := c.simpleQuery(`BEGIN; SELECT 1 AS a; SELECT 2 AS b; COMMIT`, "")
+	if err != nil {
+		return nil, err
+	}
+	return []queryResult{res}, nil
+}
+
+// runEmptyQuery sends a simple-Query packet with an empty SQL body. Per
+// the Postgres wire protocol the server answers with EmptyQueryResponse
+// ('I') followed by ReadyForQuery — no CommandComplete and no row data.
+// A correct recorder suppresses this as a no-op; a naive recorder emits
+// a ghost invocation with empty sqlNormalized and class=UNKNOWN.
+func runEmptyQuery(c *pgClient) ([]queryResult, error) {
+	res, err := c.simpleQuery(``, "")
+	if err != nil {
+		return nil, err
+	}
+	return []queryResult{res}, nil
+}
+
 func runQueries(c *pgClient, queries ...string) ([]queryResult, error) {
 	results := make([]queryResult, 0, len(queries))
 	for _, q := range queries {
@@ -395,6 +427,9 @@ func (c *pgClient) simpleQuery(sql, copyInput string) (queryResult, error) {
 			// CopyDone from server after COPY TO STDOUT.
 		case 'N':
 		case 'n', 's':
+		case 'I':
+			// EmptyQueryResponse — server received an empty query string.
+			// No CommandComplete follows; ReadyForQuery terminates the cycle.
 		case 'Z':
 			return res, nil
 		case 'E':

--- a/postgres-wire-features/main.go
+++ b/postgres-wire-features/main.go
@@ -1,0 +1,517 @@
+package main
+
+import (
+	"bytes"
+	"crypto/md5"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+type pgClient struct {
+	conn net.Conn
+	user string
+}
+
+type queryResult struct {
+	SQL      string     `json:"sql"`
+	Commands []string   `json:"commands"`
+	Rows     [][]string `json:"rows"`
+	CopyData []string   `json:"copyData,omitempty"`
+}
+
+type caseResult struct {
+	Name   string        `json:"name"`
+	Error  string        `json:"error,omitempty"`
+	Result []queryResult `json:"result,omitempty"`
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok\n"))
+	})
+
+	cases := map[string]func() ([]queryResult, error){
+		"setup":           runSetup,
+		"dml":             runDML,
+		"catalog-cte":     runCatalogCTE,
+		"catalog-sub":     runCatalogSubselect,
+		"catalog-setop":   runCatalogSetOp,
+		"copy":            runCopy,
+		"prepare":         runPrepareExecute,
+		"cursor":          runCursor,
+		"admin":           runAdminStatements,
+		"validation-ping": runValidationPing,
+	}
+
+	for name, fn := range cases {
+		name, fn := name, fn
+		mux.HandleFunc("/case/"+name, func(w http.ResponseWriter, _ *http.Request) {
+			writeCase(w, name, fn)
+		})
+	}
+
+	mux.HandleFunc("/run/all", func(w http.ResponseWriter, _ *http.Request) {
+		order := []string{
+			"setup",
+			"dml",
+			"catalog-cte",
+			"catalog-sub",
+			"catalog-setop",
+			"copy",
+			"prepare",
+			"cursor",
+			"admin",
+			"validation-ping",
+		}
+		results := make([]caseResult, 0, len(order))
+		status := http.StatusOK
+		for _, name := range order {
+			res, err := cases[name]()
+			item := caseResult{Name: name, Result: res}
+			if err != nil {
+				item.Error = err.Error()
+				status = http.StatusInternalServerError
+			}
+			results = append(results, item)
+		}
+		writeJSON(w, status, results)
+	})
+
+	addr := env("ADDR", ":8080")
+	log.Printf("postgres-wire-features listening on %s", addr)
+	log.Fatal(http.ListenAndServe(addr, mux))
+}
+
+func writeCase(w http.ResponseWriter, name string, fn func() ([]queryResult, error)) {
+	res, err := fn()
+	status := http.StatusOK
+	item := caseResult{Name: name, Result: res}
+	if err != nil {
+		status = http.StatusInternalServerError
+		item.Error = err.Error()
+	}
+	writeJSON(w, status, item)
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(v)
+}
+
+func withClient(fn func(*pgClient) ([]queryResult, error)) ([]queryResult, error) {
+	c, err := dialPostgres()
+	if err != nil {
+		return nil, err
+	}
+	defer c.conn.Close()
+	return fn(c)
+}
+
+func runSetup() ([]queryResult, error) {
+	return withClient(func(c *pgClient) ([]queryResult, error) {
+		return runQueries(c,
+			`DROP TABLE IF EXISTS gap_items`,
+			`CREATE TABLE gap_items (id SERIAL PRIMARY KEY, name TEXT NOT NULL)`,
+			`INSERT INTO gap_items(name) VALUES ('seed-a'), ('seed-b')`,
+			`CREATE TABLE IF NOT EXISTS flyway_schema_history (
+				installed_rank INT PRIMARY KEY,
+				version TEXT,
+				description TEXT,
+				type TEXT,
+				script TEXT,
+				checksum INT,
+				installed_by TEXT,
+				installed_on TIMESTAMP DEFAULT now(),
+				execution_time INT,
+				success BOOLEAN
+			)`,
+		)
+	})
+}
+
+func runDML() ([]queryResult, error) {
+	return withClient(func(c *pgClient) ([]queryResult, error) {
+		return runQueries(c,
+			`INSERT INTO flyway_schema_history
+				(installed_rank, version, description, type, script, checksum, installed_by, execution_time, success)
+			 VALUES (1, '1', 'v3 dml classifier repro', 'SQL', 'V1__gap.sql', 42, 'gap-app', 7, true)
+			 ON CONFLICT (installed_rank) DO UPDATE SET checksum = EXCLUDED.checksum`,
+			`UPDATE gap_items SET name = name || '-updated' WHERE id = 1`,
+			`DELETE FROM gap_items WHERE name = 'never-present'`,
+			`MERGE INTO gap_items AS target
+			 USING (VALUES (2, 'seed-b-merged')) AS src(id, name)
+			 ON target.id = src.id
+			 WHEN MATCHED THEN UPDATE SET name = src.name
+			 WHEN NOT MATCHED THEN INSERT (id, name) VALUES (src.id, src.name)`,
+		)
+	})
+}
+
+func runCatalogCTE() ([]queryResult, error) {
+	return withClient(func(c *pgClient) ([]queryResult, error) {
+		return runQueries(c,
+			`WITH catalog_rels AS (
+				SELECT oid, relname FROM pg_catalog.pg_class WHERE relname IN ('pg_class', 'pg_type')
+			 )
+			 SELECT relname FROM catalog_rels ORDER BY relname`,
+		)
+	})
+}
+
+func runCatalogSubselect() ([]queryResult, error) {
+	return withClient(func(c *pgClient) ([]queryResult, error) {
+		return runQueries(c,
+			`SELECT relname
+			 FROM (SELECT relname FROM pg_catalog.pg_class WHERE relname = 'pg_class') AS catalog_subquery`,
+		)
+	})
+}
+
+func runCatalogSetOp() ([]queryResult, error) {
+	return withClient(func(c *pgClient) ([]queryResult, error) {
+		return runQueries(c,
+			`SELECT relname FROM pg_catalog.pg_class WHERE relname = 'pg_class'
+			 UNION
+			 SELECT relname FROM pg_catalog.pg_class WHERE relname = 'pg_type'
+			 ORDER BY relname`,
+		)
+	})
+}
+
+func runCopy() ([]queryResult, error) {
+	return withClient(func(c *pgClient) ([]queryResult, error) {
+		var all []queryResult
+		setup, err := runQueries(c, `TRUNCATE gap_items RESTART IDENTITY`)
+		if err != nil {
+			return all, err
+		}
+		all = append(all, setup...)
+
+		in, err := c.simpleQuery(`COPY gap_items(name) FROM STDIN`, "copy-a\ncopy-b\n")
+		if err != nil {
+			return all, err
+		}
+		all = append(all, in)
+
+		out, err := c.simpleQuery(`COPY (SELECT id, name FROM gap_items ORDER BY id) TO STDOUT`, "")
+		if err != nil {
+			return all, err
+		}
+		all = append(all, out)
+		return all, nil
+	})
+}
+
+func runPrepareExecute() ([]queryResult, error) {
+	return withClient(func(c *pgClient) ([]queryResult, error) {
+		return runQueries(c,
+			`PREPARE gap_lookup(int) AS SELECT name FROM gap_items WHERE id = $1`,
+			`EXECUTE gap_lookup(1)`,
+			`DEALLOCATE gap_lookup`,
+		)
+	})
+}
+
+func runCursor() ([]queryResult, error) {
+	return withClient(func(c *pgClient) ([]queryResult, error) {
+		return runQueries(c,
+			`BEGIN`,
+			`DECLARE gap_cursor CURSOR FOR SELECT id, name FROM gap_items ORDER BY id`,
+			`FETCH 1 FROM gap_cursor`,
+			`FETCH 1 FROM gap_cursor`,
+			`CLOSE gap_cursor`,
+			`COMMIT`,
+		)
+	})
+}
+
+func runAdminStatements() ([]queryResult, error) {
+	return withClient(func(c *pgClient) ([]queryResult, error) {
+		return runQueries(c,
+			`ANALYZE gap_items`,
+			`REINDEX TABLE gap_items`,
+			`BEGIN`,
+			`LOCK TABLE gap_items IN ACCESS SHARE MODE`,
+			`COMMIT`,
+			`DO $$ BEGIN PERFORM 1; END $$`,
+			`CREATE OR REPLACE PROCEDURE gap_noop() LANGUAGE plpgsql AS $$ BEGIN PERFORM 1; END $$`,
+			`CALL gap_noop()`,
+		)
+	})
+}
+
+func runValidationPing() ([]queryResult, error) {
+	return withClient(func(c *pgClient) ([]queryResult, error) {
+		return runQueries(c,
+			`SELECT 'ok'`,
+			`SELECT true`,
+			`SELECT NULL`,
+			`SELECT 1`,
+		)
+	})
+}
+
+func runQueries(c *pgClient, queries ...string) ([]queryResult, error) {
+	results := make([]queryResult, 0, len(queries))
+	for _, q := range queries {
+		res, err := c.simpleQuery(q, "")
+		if err != nil {
+			return results, err
+		}
+		results = append(results, res)
+	}
+	return results, nil
+}
+
+func dialPostgres() (*pgClient, error) {
+	host := env("PGHOST", "127.0.0.1")
+	port := env("PGPORT", "5432")
+	user := env("PGUSER", "postgres")
+	db := env("PGDATABASE", "postgres")
+	password := env("PGPASSWORD", "")
+
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, port), 10*time.Second)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &pgClient{conn: conn, user: user}
+	if err := c.startup(user, db, password); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	return c, nil
+}
+
+func (c *pgClient) startup(user, db, password string) error {
+	var body bytes.Buffer
+	_ = binary.Write(&body, binary.BigEndian, int32(196608))
+	writeCString(&body, "user")
+	writeCString(&body, user)
+	writeCString(&body, "database")
+	writeCString(&body, db)
+	writeCString(&body, "client_encoding")
+	writeCString(&body, "UTF8")
+	body.WriteByte(0)
+
+	msg := withLength(body.Bytes())
+	if _, err := c.conn.Write(msg); err != nil {
+		return err
+	}
+
+	for {
+		tag, payload, err := c.readMessage()
+		if err != nil {
+			return err
+		}
+		switch tag {
+		case 'R':
+			if len(payload) < 4 {
+				return errors.New("short authentication message")
+			}
+			code := binary.BigEndian.Uint32(payload[:4])
+			switch code {
+			case 0:
+			case 3:
+				if password == "" {
+					return errors.New("postgres requested cleartext password, but PGPASSWORD is empty")
+				}
+				if err := c.sendPassword(password); err != nil {
+					return err
+				}
+			case 5:
+				if password == "" {
+					return errors.New("postgres requested md5 password, but PGPASSWORD is empty")
+				}
+				if len(payload) < 8 {
+					return errors.New("short md5 authentication salt")
+				}
+				if err := c.sendPassword(md5Password(user, password, payload[4:8])); err != nil {
+					return err
+				}
+			default:
+				return fmt.Errorf("unsupported postgres authentication code %d", code)
+			}
+		case 'S', 'K':
+		case 'Z':
+			return nil
+		case 'E':
+			return errors.New(parseError(payload))
+		default:
+			return fmt.Errorf("unexpected startup message %q", tag)
+		}
+	}
+}
+
+func (c *pgClient) sendPassword(password string) error {
+	var body bytes.Buffer
+	writeCString(&body, password)
+	return c.writeMessage('p', body.Bytes())
+}
+
+func (c *pgClient) simpleQuery(sql, copyInput string) (queryResult, error) {
+	res := queryResult{SQL: oneLine(sql)}
+	var body bytes.Buffer
+	writeCString(&body, sql)
+	if err := c.writeMessage('Q', body.Bytes()); err != nil {
+		return res, err
+	}
+
+	for {
+		tag, payload, err := c.readMessage()
+		if err != nil {
+			return res, err
+		}
+		switch tag {
+		case 'T':
+			// Row descriptions are not needed for this repro; DataRow carries values.
+		case 'D':
+			res.Rows = append(res.Rows, parseDataRow(payload))
+		case 'C':
+			res.Commands = append(res.Commands, trimCString(payload))
+		case 'G':
+			if copyInput == "" {
+				return res, errors.New("server requested COPY input but no copy data was provided")
+			}
+			if err := c.writeMessage('d', []byte(copyInput)); err != nil {
+				return res, err
+			}
+			if err := c.writeMessage('c', nil); err != nil {
+				return res, err
+			}
+		case 'H':
+			// COPY OUT starts; data arrives in CopyData messages.
+		case 'd':
+			res.CopyData = append(res.CopyData, strings.TrimRight(string(payload), "\n"))
+		case 'c':
+			// CopyDone from server after COPY TO STDOUT.
+		case 'N':
+		case 'n', 's':
+		case 'Z':
+			return res, nil
+		case 'E':
+			return res, errors.New(parseError(payload))
+		default:
+			return res, fmt.Errorf("unhandled postgres message %q for query %q", tag, oneLine(sql))
+		}
+	}
+}
+
+func (c *pgClient) readMessage() (byte, []byte, error) {
+	header := make([]byte, 5)
+	if _, err := io.ReadFull(c.conn, header); err != nil {
+		return 0, nil, err
+	}
+	size := int(binary.BigEndian.Uint32(header[1:5]))
+	if size < 4 {
+		return 0, nil, fmt.Errorf("invalid postgres message length %d", size)
+	}
+	payload := make([]byte, size-4)
+	if _, err := io.ReadFull(c.conn, payload); err != nil {
+		return 0, nil, err
+	}
+	return header[0], payload, nil
+}
+
+func (c *pgClient) writeMessage(tag byte, payload []byte) error {
+	msg := make([]byte, 1, 1+4+len(payload))
+	msg[0] = tag
+	msg = append(msg, withLength(payload)...)
+	_, err := c.conn.Write(msg)
+	return err
+}
+
+func withLength(payload []byte) []byte {
+	msg := make([]byte, 4, 4+len(payload))
+	binary.BigEndian.PutUint32(msg[:4], uint32(len(payload)+4))
+	return append(msg, payload...)
+}
+
+func writeCString(buf *bytes.Buffer, value string) {
+	buf.WriteString(value)
+	buf.WriteByte(0)
+}
+
+func parseDataRow(payload []byte) []string {
+	if len(payload) < 2 {
+		return nil
+	}
+	n := int(binary.BigEndian.Uint16(payload[:2]))
+	pos := 2
+	row := make([]string, 0, n)
+	for i := 0; i < n && pos+4 <= len(payload); i++ {
+		size := int(int32(binary.BigEndian.Uint32(payload[pos : pos+4])))
+		pos += 4
+		if size == -1 {
+			row = append(row, "NULL")
+			continue
+		}
+		if pos+size > len(payload) {
+			row = append(row, "<short-value>")
+			break
+		}
+		row = append(row, string(payload[pos:pos+size]))
+		pos += size
+	}
+	return row
+}
+
+func parseError(payload []byte) string {
+	parts := make([]string, 0, 4)
+	for len(payload) > 0 && payload[0] != 0 {
+		fieldType := payload[0]
+		payload = payload[1:]
+		idx := bytes.IndexByte(payload, 0)
+		if idx < 0 {
+			break
+		}
+		value := string(payload[:idx])
+		payload = payload[idx+1:]
+		if fieldType == 'S' || fieldType == 'C' || fieldType == 'M' {
+			parts = append(parts, value)
+		}
+	}
+	if len(parts) == 0 {
+		return "postgres error"
+	}
+	return strings.Join(parts, ": ")
+}
+
+func trimCString(payload []byte) string {
+	return strings.TrimRight(string(payload), "\x00")
+}
+
+func oneLine(sql string) string {
+	return strings.Join(strings.Fields(sql), " ")
+}
+
+func env(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
+}
+
+func md5Password(user, password string, salt []byte) string {
+	first := md5.Sum([]byte(password + user))
+	firstHex := make([]byte, hex.EncodedLen(len(first)))
+	hex.Encode(firstHex, first[:])
+	secondInput := append(firstHex, salt...)
+	second := md5.Sum(secondInput)
+	return "md5" + hex.EncodeToString(second[:])
+}

--- a/postgres-wire-features/test.sh
+++ b/postgres-wire-features/test.sh
@@ -9,12 +9,24 @@ echo -e "\n--- /health (sanity) ---"
 curl -s -w "  HTTP %{http_code}\n" "$BASE_URL/health"
 
 # /run/all exercises every scenario (setup, dml, catalog-{cte,sub,setop},
-# copy, prepare, cursor, admin, validation-ping) inside a single HTTP
-# request. That keeps the recorded HTTP testcase count small (one per
-# scenario batch) while still driving the full Postgres wire surface
+# copy, prepare, cursor, admin, validation-ping, multistatement,
+# empty-query) inside a single HTTP request. That keeps the recorded HTTP
+# testcase count small while still driving the full Postgres wire surface
 # Keploy needs to see.
 echo -e "\n--- /run/all (one call exercises every scenario) ---"
 curl -s -w "\n  HTTP %{http_code}\n" "$BASE_URL/run/all" -o /tmp/run-all.json
 echo "  response bytes: $(wc -c </tmp/run-all.json)"
+
+# Standalone hits for scenarios that target specific v3 protocol edges.
+# Running them on fresh connections (the /case endpoints use withClient)
+# keeps them isolated from the long-lived /run/all connection so the
+# recorder sees a clean connection boundary around each.
+echo -e "\n--- /case/multistatement (BEGIN; SELECT 1; SELECT 2; COMMIT as ONE Q packet) ---"
+curl -s -w "  HTTP %{http_code}\n" "$BASE_URL/case/multistatement" -o /tmp/case-multistatement.json
+echo "  response bytes: $(wc -c </tmp/case-multistatement.json)"
+
+echo -e "\n--- /case/empty-query (Q packet with empty SQL body) ---"
+curl -s -w "  HTTP %{http_code}\n" "$BASE_URL/case/empty-query" -o /tmp/case-empty-query.json
+echo "  response bytes: $(wc -c </tmp/case-empty-query.json)"
 
 echo -e "\n=== done ==="

--- a/postgres-wire-features/test.sh
+++ b/postgres-wire-features/test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://localhost:8080}"
+
+echo "=== postgres-wire-features traffic ==="
+
+echo -e "\n--- /health (sanity) ---"
+curl -s -w "  HTTP %{http_code}\n" "$BASE_URL/health"
+
+echo -e "\n--- /run/all (one call exercises every scenario) ---"
+curl -s -w "\n  HTTP %{http_code}\n" "$BASE_URL/run/all" -o /tmp/run-all.json
+echo "  response bytes: $(wc -c </tmp/run-all.json)"
+
+echo -e "\n--- individual scenarios ---"
+for name in setup dml catalog-cte catalog-sub catalog-setop copy prepare cursor admin validation-ping; do
+  curl -s -w "  /case/$name: HTTP %{http_code}\n" "$BASE_URL/case/$name" -o /dev/null
+done
+
+echo -e "\n=== done ==="

--- a/postgres-wire-features/test.sh
+++ b/postgres-wire-features/test.sh
@@ -5,8 +5,11 @@ BASE_URL="${BASE_URL:-http://localhost:8080}"
 
 echo "=== postgres-wire-features traffic ==="
 
+# --fail-with-body makes curl exit non-zero on HTTP >= 400 while still
+# printing the response body, so a failing endpoint surfaces as a real
+# shell failure instead of silently producing a bad recording.
 echo -e "\n--- /health (sanity) ---"
-curl -s -w "  HTTP %{http_code}\n" "$BASE_URL/health"
+curl -s --fail-with-body -w "  HTTP %{http_code}\n" "$BASE_URL/health"
 
 # /run/all exercises every scenario (setup, dml, catalog-{cte,sub,setop},
 # copy, prepare, cursor, admin, validation-ping, multistatement,
@@ -14,7 +17,7 @@ curl -s -w "  HTTP %{http_code}\n" "$BASE_URL/health"
 # testcase count small while still driving the full Postgres wire surface
 # Keploy needs to see.
 echo -e "\n--- /run/all (one call exercises every scenario) ---"
-curl -s -w "\n  HTTP %{http_code}\n" "$BASE_URL/run/all" -o /tmp/run-all.json
+curl -s --fail-with-body -w "\n  HTTP %{http_code}\n" "$BASE_URL/run/all" -o /tmp/run-all.json
 echo "  response bytes: $(wc -c </tmp/run-all.json)"
 
 # Standalone hits for scenarios that target specific v3 protocol edges.
@@ -22,11 +25,11 @@ echo "  response bytes: $(wc -c </tmp/run-all.json)"
 # keeps them isolated from the long-lived /run/all connection so the
 # recorder sees a clean connection boundary around each.
 echo -e "\n--- /case/multistatement (BEGIN; SELECT 1; SELECT 2; COMMIT as ONE Q packet) ---"
-curl -s -w "  HTTP %{http_code}\n" "$BASE_URL/case/multistatement" -o /tmp/case-multistatement.json
+curl -s --fail-with-body -w "  HTTP %{http_code}\n" "$BASE_URL/case/multistatement" -o /tmp/case-multistatement.json
 echo "  response bytes: $(wc -c </tmp/case-multistatement.json)"
 
 echo -e "\n--- /case/empty-query (Q packet with empty SQL body) ---"
-curl -s -w "  HTTP %{http_code}\n" "$BASE_URL/case/empty-query" -o /tmp/case-empty-query.json
+curl -s --fail-with-body -w "  HTTP %{http_code}\n" "$BASE_URL/case/empty-query" -o /tmp/case-empty-query.json
 echo "  response bytes: $(wc -c </tmp/case-empty-query.json)"
 
 echo -e "\n=== done ==="

--- a/postgres-wire-features/test.sh
+++ b/postgres-wire-features/test.sh
@@ -8,13 +8,13 @@ echo "=== postgres-wire-features traffic ==="
 echo -e "\n--- /health (sanity) ---"
 curl -s -w "  HTTP %{http_code}\n" "$BASE_URL/health"
 
+# /run/all exercises every scenario (setup, dml, catalog-{cte,sub,setop},
+# copy, prepare, cursor, admin, validation-ping) inside a single HTTP
+# request. That keeps the recorded HTTP testcase count small (one per
+# scenario batch) while still driving the full Postgres wire surface
+# Keploy needs to see.
 echo -e "\n--- /run/all (one call exercises every scenario) ---"
 curl -s -w "\n  HTTP %{http_code}\n" "$BASE_URL/run/all" -o /tmp/run-all.json
 echo "  response bytes: $(wc -c </tmp/run-all.json)"
-
-echo -e "\n--- individual scenarios ---"
-for name in setup dml catalog-cte catalog-sub catalog-setop copy prepare cursor admin validation-ping; do
-  curl -s -w "  /case/$name: HTTP %{http_code}\n" "$BASE_URL/case/$name" -o /dev/null
-done
 
 echo -e "\n=== done ==="


### PR DESCRIPTION
## Summary

Adds `postgres-wire-features/`, a stdlib-only Go HTTP service that speaks the Postgres v3 frontend/backend protocol directly (no driver). It packages ten Postgres feature areas behind `GET /run/all` and `GET /case/<name>` so a single Keploy record/replay pass covers a wide surface of wire-protocol message types in one sample.

| Scenario | Statements exercised |
| --- | --- |
| `setup` | `DROP TABLE`, `CREATE TABLE`, `INSERT`, `CREATE TABLE IF NOT EXISTS` |
| `dml` | `INSERT … ON CONFLICT DO UPDATE`, `UPDATE`, `DELETE`, `MERGE` |
| `catalog-cte` | `WITH … SELECT FROM pg_catalog.pg_class` |
| `catalog-sub` | `SELECT … FROM (SELECT …) AS s` |
| `catalog-setop` | `SELECT … UNION SELECT …` |
| `copy` | `TRUNCATE`, `COPY … FROM STDIN`, `COPY … TO STDOUT` |
| `prepare` | `PREPARE`, `EXECUTE`, `DEALLOCATE` |
| `cursor` | `BEGIN`, `DECLARE CURSOR`, `FETCH`×2, `CLOSE`, `COMMIT` |
| `admin` | `ANALYZE`, `REINDEX`, `LOCK TABLE`, `DO $$ … $$`, `CREATE PROCEDURE`, `CALL` |
| `validation-ping` | `SELECT 'ok'`, `SELECT true`, `SELECT NULL`, `SELECT 1` |

Each scenario's JSON response carries the per-statement command tag, rows, and (for `COPY TO STDOUT`) the `copyData` payload, so replay diffs localise cleanly to the Postgres statement that differed.

## Why stdlib / no driver

Driver libraries hide a number of wire-level details (extended-query portals, `CopyData` / `CopyDone` framing, raw command tags). Talking the v3 protocol directly over `net.Conn` means the recorded Postgres traffic is what Keploy's proxy actually saw, which is the point of a wire-protocol sample.

## Layout

Mirrors the `http-postgres/` convention:

- `main.go` — server + scenarios
- `Dockerfile` — two-stage (golang:1.24-alpine → alpine:3.19)
- `docker-compose.yml` — `api` + `db` (postgres:16-alpine) with healthcheck
- `test.sh` — traffic script (`/health`, `/run/all`, each `/case/<name>`)
- `README.md` — record & replay instructions

## Related

- Pipeline: keploy/integrations#134
- Tracking issue (v3 gaps this sample exposes): keploy/enterprise#1921

## Test plan

- [ ] `docker compose up --build` brings the stack up and `curl http://localhost:8080/health` returns `ok`
- [ ] `./test.sh` exercises every `/case/<name>` and `/run/all`
- [ ] `keploy record -c "docker compose up" --container-name api --delay 10` captures HTTP tests + Postgres mocks under `keploy/`
- [ ] `keploy test -c "docker compose up" --container-name api --delay 20` replays; diffs are reported per-scenario in the JSON body

🤖 Generated with [Claude Code](https://claude.com/claude-code)