### PR TITLE
fix(http-postgres): use deterministic company names to stop record/replay flake

### DIFF
--- a/http-postgres/test.sh
+++ b/http-postgres/test.sh
@@ -3,10 +3,15 @@ set -euo pipefail
 
 BASE_URL="http://localhost:8080"
 
-# Generate random company names
-random_name() {
-  head -c 8 /dev/urandom | base64 | tr -dc 'a-zA-Z' | head -c 10
-}
+# Deterministic per-iteration company names. Previously this used a random
+# generator (head -c 8 /dev/urandom | base64 | tr -dc 'a-zA-Z' | head -c 10)
+# producing names like "Company_<8-10 random alphas>_<i>", which differ
+# between record and replay runs of the Keploy http-postgres CI pipeline.
+# The postgres-v3 replayer matches mocks by bind value, so divergent random
+# names triggered intermittent "no invocation matched" errors on test-4 /
+# test-21 (the POST /companies inserts). A deterministic counter keeps
+# inserts unique within a single run while guaranteeing record/replay agree
+# byte-for-byte on the bind payload.
 
 echo "=== Rapid-fire API test (25+ calls) ==="
 
@@ -14,7 +19,7 @@ echo "=== Rapid-fire API test (25+ calls) ==="
 echo -e "\n--- Creating 10 unique companies (parallel) ---"
 pids=()
 for i in $(seq 1 10); do
-  name="Company_$(random_name)_$i"
+  name="Company_${i}"
   curl -s -w "  HTTP %{http_code}\n" -X POST "$BASE_URL/companies" \
     -H 'Content-Type: application/json' \
     -d "{\"name\": \"$name\"}" &


### PR DESCRIPTION
## Summary

The http-postgres pipeline in keploy/integrations intermittently fails on `test-4` / `test-21` (the `POST /companies` inserts) with the postgres-v3 strict-bind-matcher signature:

```
🐰 Keploy(agent): ERROR transactional: no invocation matched
  Type: postgres_v3
  sqlHead: INSERT INTO companies (name) VALUES ($1) RETURNING id, name, created_at
  binds: 1, candidates: 6
  bindShape: ["len=16/ascii"]
  reason: bind values diverged from every recorded invocation
```

## RCA

`http-postgres/test.sh` generated company names via a random 8–10 char alpha generator:

```bash
random_name() { head -c 8 /dev/urandom | base64 | tr -dc 'a-zA-Z' | head -c 10; }
name="Company_$(random_name)_$i"
```

Different bytes between record and replay → strict matcher misses every recorded candidate. The `KEPLOY_PG_V3_BINDSHAPE_FALLBACK=1` setting in integrations CI doesn't catch it either, because the `tr -dc 'a-zA-Z'` step can drop digits — final length is 8 to 10 chars, so even the shape-equal fallback fails when replay produces a length absent from the recorded cohort.

## Fix

Replace the random generator with a deterministic per-iteration counter. The 10 inserts stay unique within a single run and record/replay agree byte-for-byte on the bind payload:

```bash
name="Company_${i}"
```

## Failing pipelines (keploy/integrations)

- 711 (PR #153 mongo)
- 713 (post-merge of PR #154)
- 717 (PR #155 prior to fixes)
- 722 (PR #157 lint cleanup)
- and many earlier runs across multiple PRs

All failed on `http-postgres/1` (record-build-replay-build leg) at the same SQL hash with `bindShape: len=16/ascii`.

## Test plan

- [x] `bash -n http-postgres/test.sh` clean
- [ ] Next keploy/integrations PR run validates `http-postgres/1` is no longer flaky on this signature