### PR TITLE
feat: app for testing concurrent sampling

### DIFF
--- a/sampling-test/README.md
+++ b/sampling-test/README.md
@@ -1,0 +1,26 @@
+# sampling-test
+
+Minimal HTTP server used by the Keploy `--enable-sampling` CI pipeline
+(`.github/workflows/sampling-test.yml` in the keploy/keploy repo).
+
+`GET /work` sleeps `HANDLER_DELAY_MS` (default 500ms) before responding so a
+burst of concurrent requests overlaps inside the Keploy proxy. With
+`--enable-sampling=K`, the proxy only captures K concurrent in-flight
+requests; the rest are forwarded transparently without being recorded.
+
+The companion `curl.sh` fires `TOTAL_REQUESTS` (default 20) curls in
+parallel — each one its own TCP connection — to exceed the sampling
+budget and exercise the bypass path.
+
+After the burst, the workflow asserts:
+
+- every curl saw a 2xx response (clients are never broken by bypass), and
+- `K <= captured_test_cases < TOTAL_REQUESTS`.
+
+## Run locally
+
+```bash
+go build -o sampling-test
+./sampling-test &
+TOTAL_REQUESTS=20 bash curl.sh
+```

--- a/sampling-test/curl.sh
+++ b/sampling-test/curl.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Fire $TOTAL_REQUESTS concurrent GET /work calls against the sample app.
+# Each curl uses its own TCP connection (no -K, no session reuse), so the
+# Keploy proxy sees TOTAL_REQUESTS connection-acquire attempts inside the
+# server-side handler delay window — far more than --enable-sampling slots,
+# forcing the bypass path on most of them.
+#
+# Writes one status-code line per request to $RESULTS_DIR/req-<i>.status.
+# Caller (workflow / verify script) inspects those files to assert that
+# every client got a 2xx response (no 502s, no timeouts) regardless of
+# whether the request was captured.
+
+set -euo pipefail
+
+TOTAL_REQUESTS="${TOTAL_REQUESTS:-20}"
+TARGET_URL="${TARGET_URL:-http://localhost:8080/work}"
+RESULTS_DIR="${RESULTS_DIR:-./curl-results}"
+CONNECT_TIMEOUT="${CONNECT_TIMEOUT:-5}"
+MAX_TIME="${MAX_TIME:-15}"
+
+mkdir -p "$RESULTS_DIR"
+rm -f "$RESULTS_DIR"/req-*.status "$RESULTS_DIR"/req-*.body
+
+echo "Firing $TOTAL_REQUESTS concurrent requests to $TARGET_URL"
+
+pids=()
+for i in $(seq 1 "$TOTAL_REQUESTS"); do
+    (
+        # -o body file, -w status code, -s silent, --no-keepalive so each
+        # curl invocation opens its own TCP connection.
+        status=$(curl -s -o "$RESULTS_DIR/req-${i}.body" \
+            -w "%{http_code}" \
+            --no-keepalive \
+            --connect-timeout "$CONNECT_TIMEOUT" \
+            --max-time "$MAX_TIME" \
+            "$TARGET_URL" || echo "000")
+        echo "$status" > "$RESULTS_DIR/req-${i}.status"
+    ) &
+    pids+=("$!")
+done
+
+# Wait for every concurrent curl to finish.
+fail=0
+for pid in "${pids[@]}"; do
+    if ! wait "$pid"; then
+        fail=$((fail + 1))
+    fi
+done
+
+ok=0
+nonok=0
+for f in "$RESULTS_DIR"/req-*.status; do
+    code=$(cat "$f")
+    if [[ "$code" =~ ^2[0-9][0-9]$ ]]; then
+        ok=$((ok + 1))
+    else
+        nonok=$((nonok + 1))
+        echo "non-2xx response from $(basename "$f"): $code"
+    fi
+done
+
+echo "curl summary: total=$TOTAL_REQUESTS ok=$ok non2xx=$nonok wait_failures=$fail"
+
+# Any non-2xx is a client-visible failure (proxy must never break clients
+# just because the request was bypassed for sampling). Fail loudly.
+if [[ "$nonok" -ne 0 || "$fail" -ne 0 ]]; then
+    exit 1
+fi

--- a/sampling-test/go.mod
+++ b/sampling-test/go.mod
@@ -1,0 +1,3 @@
+module github.com/keploy/samples-go/sampling-test
+
+go 1.24.2

--- a/sampling-test/main.go
+++ b/sampling-test/main.go
@@ -1,0 +1,64 @@
+// Package main is a minimal HTTP server used by the Keploy sampling-test
+// pipeline. The /work handler sleeps for HANDLER_DELAY (default 500ms) so a
+// burst of concurrent requests overlaps inside the Keploy proxy, exercising
+// the --enable-sampling slot semaphore in pkg/agent/proxy/incoming.
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"sync/atomic"
+	"time"
+)
+
+var counter atomic.Uint64
+
+func parseDelay() time.Duration {
+	if v := os.Getenv("HANDLER_DELAY_MS"); v != "" {
+		if ms, err := strconv.Atoi(v); err == nil && ms >= 0 {
+			return time.Duration(ms) * time.Millisecond
+		}
+	}
+	return 500 * time.Millisecond
+}
+
+func main() {
+	delay := parseDelay()
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	})
+
+	mux.HandleFunc("/work", func(w http.ResponseWriter, r *http.Request) {
+		id := counter.Add(1)
+		time.Sleep(delay)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":         id,
+			"path":       r.URL.Path,
+			"delayMs":    delay.Milliseconds(),
+			"clientAddr": r.RemoteAddr,
+		})
+	})
+
+	addr := ":" + port
+	log.Printf("sampling-test listening on %s (handler delay %s)", addr, delay)
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	if err := srv.ListenAndServe(); err != nil {
+		log.Fatalf("server: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a minimal `sampling-test` sample app used by the new `--enable-sampling` end-to-end CI pipeline in keploy/keploy ([#4209](https://github.com/keploy/keploy/pull/4209)).

The app is intentionally minimal — stdlib `net/http` only, no external dependencies, no database. Its only job is to make the Keploy proxy's sampling slot semaphore observable from the outside:

- `GET /work` sleeps `HANDLER_DELAY_MS` (default **500 ms**) before responding. The long handler delay guarantees that a concurrent burst of curl requests overlaps **inside the Keploy proxy**, so the slot semaphore is genuinely contended.
- `GET /health` is a non-sleeping readiness probe.
- `curl.sh` fires `TOTAL_REQUESTS` (default **20**) curls in parallel via `&` + `wait`, each with `--no-keepalive` so every request gets its own TCP connection. It records every response code and exits non-zero if any client saw non-2xx.

With `keploy record --enable-sampling=5`, the expected outcome is that 5 of the 20 requests are captured as test cases (slot count saturated) while the remaining 15 are proxied transparently without being recorded. The companion keploy workflow asserts exactly that.

## Files added

```
sampling-test/
├── go.mod          # stdlib-only module
├── main.go         # /work (delayed) + /health
├── curl.sh         # N concurrent requests, fails on any non-2xx
└── README.md       # how to reproduce locally
```

## Links

- Issue: keploy/keploy#4211
- Companion PR (the workflow that consumes this sample): keploy/keploy#4209

## Reproduce locally

```bash
cd sampling-test
go build -o sampling-test .
./sampling-test &
TOTAL_REQUESTS=20 bash curl.sh    # all 20 should return 200
```

Then under `keploy record --enable-sampling=5`, you should see exactly 5 `get-work-*.yaml` test cases under `./keploy/test-set-0/tests/`.

## Type of change

- [x] New sample app
- [x] Used by an existing keploy CI workflow

## Checklist

- [x] No external dependencies introduced (`go.mod` is stdlib-only)
- [x] `go build` passes on Go 1.24.2
- [x] `curl.sh` is executable and passes `bash -n` syntax check
- [x] Sample exposes a `/health` endpoint for readiness probing
- [x] No customer data, no internal hostnames, no real credentials
