### PR TITLE
fix(aerospike-tls):  Noise body.duration and disable strictMockWindow

### DIFF
--- a/aerospike-tls/keploy.yml
+++ b/aerospike-tls/keploy.yml
@@ -20,7 +20,8 @@ buildDelay: 30
 test:
     selectedTests: {}
     globalNoise:
-        global: {}
+        global:
+            body.duration: []
         test-sets: {}
     replaceWith:
         global:
@@ -66,7 +67,7 @@ test:
     schemaMatch: false
     updateTestMapping: false
     disableAutoHeaderNoise: false
-    strictMockWindow: true
+    strictMockWindow: false
 record:
     filters: []
     basePath: ""


### PR DESCRIPTION
**Description**


Two config fixes in keploy.yml for the aerospike-tls sample.
**Bug 1 — parallel/multiclient tests fail on timing differences**
The duration field in JSON responses varies between recording and replay runs. Added body.duration to globalNoise so keploy ignores it during comparison.

**Bug 2 — warmup pool Exists calls dropped during replay**
Aerospike client fires Exists calls during warmup before any test window opens. With strictMockWindow: true 


Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


How Has This Been Tested?
All 17 test cases in test-set-3 pass across 2 consecutive replay runs after these changes.



Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

