### PR TITLE
fix(sqs-samples): add /healthz for replay readiness gating

### DIFF
--- a/sqs-samples/main.go
+++ b/sqs-samples/main.go
@@ -82,6 +82,15 @@ func main() {
 
 	r := gin.Default()
 
+	// Liveness/readiness endpoint. Static routes take precedence over the
+	// "/:param" wildcard in gin, so this is not shadowed by getURL. Lets the
+	// replay driver gate on real app readiness (keploy --health-url) instead of
+	// a fixed --delay, which under CI contention fired requests before the app
+	// was serving and produced spurious "status_code got=0" failures.
+	r.GET("/healthz", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	})
+
 	r.GET("/:param", getURL)
 	r.POST("/url", putURL)
 	srv := &http.Server{


### PR DESCRIPTION
Adds a 2xx GET /healthz to the sqs sample so the keploy enterprise CI's sqs-localstack replay can gate on real app readiness (--health-url) instead of a fixed --delay — fixing the flaky 'status_code got=0' failures when the app/localstack cold-start exceeds the delay under contention. Recording unaffected (route not exercised during record). Pairs with the enterprise sqs-localstack.sh --health-url change.