### PR TITLE
fix(echo-sql): probe TCP in postgres healthcheck (fixes macOS record flake at source)

### DIFF
--- a/echo-sql/docker-compose.yml
+++ b/echo-sql/docker-compose.yml
@@ -30,11 +30,23 @@ services:
           - postgresDb
 
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres -d postgres"]
+      # Probe TCP (127.0.0.1:5432), NOT the default unix socket. During first-boot
+      # init the postgres entrypoint runs a TEMPORARY server that is reachable on
+      # the socket but not on TCP (listen_addresses is empty while init.sql runs;
+      # only afterwards does the real server bind 0.0.0.0:5432). A socket probe
+      # therefore reports "healthy" seconds before TCP accepts, so
+      # `depends_on: service_healthy` releases go-app while its TCP connect
+      # (host=postgresDb:5432, single attempt, no retry) is still refused and the
+      # app exits. The app talks to Postgres over TCP, so the gate must probe TCP.
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -p 5432 -U postgres -d postgres"]
       interval: 5s
       timeout: 5s
-      retries: 5
-      start_period: 30s
+      # Generous budget so the gate stays patient through a slow first-boot init on
+      # emulated amd64 (postgres:10.5 on Apple-silicon / colima CI runners), where
+      # the init window is many seconds wide. A fast native boot still flips healthy
+      # on the first successful probe — these only bound when we give up.
+      retries: 30
+      start_period: 90s
 
 networks:
     babab: 


### PR DESCRIPTION
## What

The `echo-sql` sample's postgres healthcheck probes the **unix socket** (`pg_isready -U postgres`). During the postgres image's first-boot init, a temporary socket-only server runs `init.sql` while TCP is **not yet listening** — so the socket probe reports `healthy` before `127.0.0.1:5432` accepts. `depends_on: service_healthy` then releases `go-app`, whose TCP connect (`host=postgresDb:5432`, single attempt, no retry) is refused → the app exits 1.

On emulated amd64 (`postgres:10.5` on Apple-silicon / colima CI runners) the init window is wide, so this is a near-permanent race — it's the root cause of the flaky `echo-sql` **macOS docker** lane in keploy/keploy (see keploy/keploy#4335). Linux is latently exposed too; it just usually wins the race.

## Fix

Probe **TCP** (`pg_isready -h 127.0.0.1 -p 5432`), matching how the app actually connects, so `service_healthy` only fires once the real server accepts TCP. Generous `retries`/`start_period` keep the gate patient through slow emulated init; a fast native boot still flips healthy on the first probe.

Fixing it in the sample (not just seddng it in one CI lane) fixes both CI lanes and every downstream user of this sample in one place.

Ref: keploy/keploy#4335