### PR TITLE
fix(proxy-stress-test): make the lane's assertions reproducible

### DIFF
--- a/proxy-stress-test/docker-compose.yml
+++ b/proxy-stress-test/docker-compose.yml
@@ -28,6 +28,30 @@ services:
              echo 'ConnectPort 443' >> /tmp/tp.conf &&
              tinyproxy -d -c /tmp/tp.conf"
 
+  # Local stand-in for httpbin.org. This lane used to drive 20 concurrent HTTPS
+  # calls at the public internet during RECORD, so the recorded response
+  # depended on whether httpbin was healthy: a slow or 5xx httpbin got baked
+  # into the expected body ("succeeded": 6, "failed": 14, "status": 503) and
+  # never reproduced on replay, failing the test set for reasons unrelated to
+  # keploy. It also burned minutes per run in 30s timeouts, and truncated one
+  # record window enough that only 3 of 5 test cases were captured.
+  #
+  # Still real HTTPS on 443, so the CONNECT-tunnel and TLS-cert-caching paths
+  # this sample exists to stress are untouched — only the far end moves
+  # in-cluster, where it is deterministic.
+  httpstub:
+    image: caddy:2-alpine
+    volumes:
+      - ./httpstub.Caddyfile:/etc/caddy/Caddyfile:ro
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --no-check-certificate -O /dev/null https://127.0.0.1/get || exit 1"]
+      interval: 2s
+      timeout: 5s
+      retries: 15
+      # Caddy mints its internal CA on first boot; give it room before the
+      # first probe counts against the retry budget.
+      start_period: 5s
+
   app:
     build: .
     container_name: proxyStressApp
@@ -36,7 +60,8 @@ services:
     environment:
       LISTEN_ADDR: ":8080"
       DATABASE_URL: "postgres://repro:repro@db:5432/reprodb?sslmode=disable"
-      HTTPS_TARGET: "https://httpbin.org/get"
+      HTTPS_TARGET: "https://httpstub/get"
+      HTTPS_POST_TARGET: "https://httpstub/post"
       HTTP_PROXY_URL: "http://proxy:3128"
       # 20 concurrent HTTPS connections through CONNECT tunnel.
       # Exercises TLS cert caching (same code path as production 42).
@@ -54,6 +79,8 @@ services:
       BG_NOISE_CONNS: "1"
     depends_on:
       db:
+        condition: service_healthy
+      httpstub:
         condition: service_healthy
     # Resource limits for GitHub Actions ubuntu-latest (4 vCPU / 16GB).
     deploy:

--- a/proxy-stress-test/httpstub.Caddyfile
+++ b/proxy-stress-test/httpstub.Caddyfile
@@ -1,0 +1,33 @@
+# Local stand-in for httpbin.org, served over real HTTPS on 443 so the
+# CONNECT-tunnel + TLS-cert-caching path this sample stresses is unchanged.
+#
+# `tls internal` mints a self-signed cert from Caddy's local CA. Nothing
+# validates it and nothing needs to: the app sets InsecureSkipVerify to accept
+# keploy's MITM cert (main.go), and keploy never validates upstream certs
+# either (proxy_v2.go, locked in by TestNewProxyTLSUpgradeFn_DestSide_
+# AlwaysInsecureSkipVerify). So no CA has to be distributed to any container.
+{
+	auto_https disable_redirects
+	admin off
+}
+
+https://httpstub:443, https://127.0.0.1:443 {
+	tls internal
+
+	handle /get {
+		header Content-Type application/json
+		# Padded to roughly httpbin /get's response size so the volume of data
+		# crossing the CONNECT tunnel stays comparable to what this lane used to
+		# exercise; the tunnel and the TLS handshake are the point, not the body.
+		respond `{"url":"https://httpstub/get","ok":true,"headers":{"Accept-Encoding":"gzip","Host":"httpstub","User-Agent":"Go-http-client/1.1"},"origin":"127.0.0.1","args":{},"padding":"0123456789012345678901234567890123456789012345678901234567890123456789"}` 200
+	}
+
+	handle /post {
+		header Content-Type application/json
+		respond `{"url":"https://httpstub/post","ok":true}` 200
+	}
+
+	handle {
+		respond 404
+	}
+}

--- a/proxy-stress-test/keploy.yml
+++ b/proxy-stress-test/keploy.yml
@@ -1,0 +1,11 @@
+# Checked in so `keploy test` ignores the one field in these responses that
+# cannot be reproduced: each stress endpoint reports its own wall-clock
+# elapsed time (main.go's `time.Since(start).String()` on /api/transfer,
+# /api/batch-transfer and /api/post-transfer). Without this, those three test
+# cases mismatch on every replay, forever.
+#
+# `keploy config --generate` is a no-op when this file exists, so CI keeps
+# working unchanged and `./test.sh` gets the same behaviour as CI.
+test:
+    globalNoise:
+        global: {"body": {"duration": []}}


### PR DESCRIPTION
## What

Every replay of `proxy-stress-test` failed **3 of its 5 test cases** — in CI and locally — and had done for at least two weeks. Neither cause is keploy; both are in this sample.

### 1. The endpoints assert on their own wall-clock time

`main.go` returns elapsed time in the response body:

| line | endpoint | field |
|---|---|---|
| 321 | `/api/transfer` | `result.Duration = time.Since(start).String()` |
| 400 | `/api/batch-transfer` | `Duration: time.Since(start).String()` |
| 463 | `/api/post-transfer` | `"duration": time.Since(start).String()` |

Those are exactly the three tests that fail. `get-health-1` and `get-health-2` pass. A recorded `"30.031440402s"` will never equal a replayed `"44.525254ms"`.

Fixed with a checked-in `keploy.yml` declaring `duration` as global body noise. **Checked in rather than patched from CI** so `./test.sh` — which already enforces report status — behaves the same as the pipeline and the two cannot drift. `keploy config --generate` is a no-op when the file exists, so keploy's CI script keeps working unchanged.

### 2. The sample recorded against the public internet

It drove 20 concurrent HTTPS requests at `https://httpbin.org` during **record**, so whatever httpbin did that minute got baked into the expected body. One CI run recorded:

```
"succeeded": 6, "failed": 14, "status": 503     <- 14 of 20 hit the 30s timeout
```

Replay serves those from mocks in milliseconds and legitimately produced `20 / 0 / 200`. The timeouts also ate one record window badly enough that only 3 of 5 test cases were captured at all.

Replaced with a local Caddy stub on the compose network. It serves **real HTTPS on 443** via `tls internal`, so the CONNECT-tunnel and TLS-cert-caching paths this sample exists to stress are untouched — only the far end moves in-cluster, where it is deterministic. No CA plumbing is needed: the app already sets `InsecureSkipVerify` to accept keploy's MITM cert, and keploy never validates upstream certs either. The `/get` body is padded to roughly httpbin's size so the tunnel carries comparable data.

## Verification

Full record → replay cycle, locally, against a keploy built from `main` with the private parsers:

| | before | after |
|---|---|---|
| replay result | **2 passed / 3 failed** | **5 passed / 0 failed** |
| `test-set-0-report.yaml` | **FAILED** | **PASSED** |
| recorded batch fields | `succeeded: 6, failed: 14, status: 503` (CI) | `succeeded: 20, failed: 0, status: 200` |

Also verified directly: the stub reaches `healthy`, `curl -k -x http://proxy:3128 https://httpstub/get` returns 200 **through the CONNECT tunnel**, and 20 concurrent GETs all return 200.

## Related

- keploy/keploy PR that arms the lane's gate (it was reporting success through all of the above). That PR requires this `keploy.yml` to be present and fails loudly if it is not, so land this one first.

## Residual, stated plainly

`/api/batch-transfer` still asserts exact `succeeded`/`failed` counts over 20 concurrent connections. The stub removes the internet as a variable but not concurrency — if one connection fails under CI load, three body fields flip at once. With the gate armed that becomes a red lane rather than an invisible one, which is the right trade, but it is the thing most likely to bite next.