### PR TITLE
docs: update download URLs from S3 to Azure

### DIFF
--- a/go-docker-timefreeze/readme.md
+++ b/go-docker-timefreeze/readme.md
@@ -7,7 +7,7 @@
 
 ```dockerfile
 # Download the time freeze agent
-ADD https://keploy-enterprise.s3.us-west-2.amazonaws.com/releases/latest/assets/go_freeze_time_amd64 /lib/keploy/go_freeze_time_amd64
+ADD https://keployenterprise.blob.core.windows.net/releases/latest/assets/go_freeze_time_amd64 /lib/keploy/go_freeze_time_amd64
 
 # Set suitable permissions
 RUN chmod +x /lib/keploy/go_freeze_time_amd64
@@ -25,7 +25,7 @@ RUN go build -tags=faketime <your_main_file>
 
 ```dockerfile
 # Download the time freeze agent
-ADD https://keploy-enterprise.s3.us-west-2.amazonaws.com/releases/latest/assets/go_freeze_time_arm64 /lib/keploy/go_freeze_time_arm64
+ADD https://keployenterprise.blob.core.windows.net/releases/latest/assets/go_freeze_time_arm64 /lib/keploy/go_freeze_time_arm64
 
 # Set suitable permissions
 RUN chmod +x /lib/keploy/go_freeze_time_arm64

--- a/go-jwt/Dockerfile
+++ b/go-jwt/Dockerfile
@@ -9,7 +9,7 @@ RUN go mod download
 
 # Copy the source code. Note the slash at the end, as explained in
 # https://docs.docker.com/reference/dockerfile/#copy
-ADD https://keploy-enterprise.s3.us-west-2.amazonaws.com/releases/latest/assets/go_freeze_time_arm64 /lib/keploy/go_freeze_time_arm64
+ADD https://keployenterprise.blob.core.windows.net/releases/latest/assets/go_freeze_time_arm64 /lib/keploy/go_freeze_time_arm64
 
 #set suitable permissions
 RUN chmod +x /lib/keploy/go_freeze_time_arm64


### PR DESCRIPTION
Download hosting has moved from the keploy-enterprise S3 bucket to Azure (keployenterprise storage account), as the S3 bucket is being decommissioned. This updates the time-freeze binary ADD URLs in the go-jwt Dockerfile and the go-docker-timefreeze readme snippets. All new URLs verified serving (HTTP 206).