### PR TITLE
fix(perf): enable mock mapping in the memory-load benchmarks

### DIFF
--- a/go-memory-load-grpc/keploy.yml
+++ b/go-memory-load-grpc/keploy.yml
@@ -84,7 +84,7 @@ report:
     summary: false
     testCaseIDs: []
     format: ""
-disableMapping: true
+disableMapping: false
 retryPassing: false
 configPath: ""
 bypassRules: []

--- a/go-memory-load-mongo/keploy.yml
+++ b/go-memory-load-mongo/keploy.yml
@@ -106,7 +106,7 @@ record:
     memoryLimit: 0
 configPath: ""
 bypassRules: []
-disableMapping: true
+disableMapping: false
 contract:
     driven: "consumer"
     mappings:

--- a/go-memory-load-mysql/keploy.yml
+++ b/go-memory-load-mysql/keploy.yml
@@ -106,7 +106,7 @@ record:
     memoryLimit: 0
 configPath: ""
 bypassRules: []
-disableMapping: true
+disableMapping: false
 contract:
     driven: "consumer"
     mappings:


### PR DESCRIPTION
## Why
`go-memory-load-{mysql,mongo,grpc}` override the shipped keploy default (`disableMapping: false`) with **`disableMapping: true`**, turning **off** mapping-based mock filtering. Without it, replay scans the **full recorded mock corpus per query** instead of loading only each test's mapped mocks (`disk.LoadByNames`).

**Measured (VM, 3255-test / 16.5k-mock MySQL recording):**
| | Wall-clock | Verdicts |
|---|---|---|
| `disableMapping: true` (full scan) | 663.7 s | 3255/3255 ✅ |
| `disableMapping: false` (mapping) | **137.4 s** | 3255/3255 ✅ |
| | **4.83× faster** | identical |

So these perf/memory benchmarks — and any CI lane built on them — were exercising the ~5×-slower fallback, not the path real users get by default.

## What
Flip the three memory-load benchmarks back to the shipped default (`disableMapping: false`).

**Safe:** these samples commit no `keploy/` recording (CI re-records each run), so the fresh recording now produces a `mappings.yaml` and replay narrows; if a recording ever lacks meaningful mappings, replay falls back to timestamp-based filtering automatically (no mock-miss).

## Not changed here
`http-sse`, `sse-redis`, `simple-grpc`, `aerospike-tls` also set `disableMapping: true` — left untouched; each should be validated individually before flipping.